### PR TITLE
disable claim button when the user have the event's NFT

### DIFF
--- a/frontend/src/pages/events/[eventid].tsx
+++ b/frontend/src/pages/events/[eventid].tsx
@@ -19,7 +19,6 @@ import { Fragment, useState, useEffect, useMemo } from "react";
 import { useGetEventById } from "../../hooks/useEventManager";
 import { useMintParticipateNFT, getMintNFTManagerContract, useGetOwnedNFTs } from "../../hooks/useMintNFTManager";
 import dayjs from "dayjs";
-import { FEATURE_NFT_SIGNATURE_MINTABLE } from "@thirdweb-dev/sdk/dist/src/constants/erc721-features";
 
 const Event = () => {
   const router = useRouter();

--- a/frontend/src/pages/events/[eventid].tsx
+++ b/frontend/src/pages/events/[eventid].tsx
@@ -75,7 +75,7 @@ const Event = () => {
 
             {(hasNftForThisEvent || mintStatus)?
               <Text>
-                Thank you for your participation!
+                You already have this event's NFT. Thank you for your participation!
               </Text>:
               <Flex
                 width="100%"


### PR DESCRIPTION
closes #114 

In `[events.js]` page, first retrieve the user's NFT's and check if the user have the event's NFT.
If it is true, hide the claim form and show the message "You already have this event's NFT. Thank you for your participation!".

Directly checking if the user have the NFT by querying groupId and eventId will be the future work.

![Screenshot from 2022-07-23 16-46-30](https://user-images.githubusercontent.com/3675691/180595893-259e0f1d-4a38-4fb4-b1a4-018c317cb4c1.png)
