### PR TITLE
fix #276 , show modal NFT view

### DIFF
--- a/frontend/src/components/atoms/nft/NFTItem.tsx
+++ b/frontend/src/components/atoms/nft/NFTItem.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Image, Text, useDisclosure } from "@chakra-ui/react";
-import { FC } from "react";
+import { useRouter } from "next/router";
+import { FC, useEffect } from "react";
 import TokenModal from "src/components/molecules/user/TokenModal";
 import { NFT } from "types/NFT";
 import { ipfs2http } from "utils/ipfs2http";
@@ -11,7 +12,14 @@ type Props = {
 };
 
 export const NFTItem: FC<Props> = ({ nft, tokenId, shareURL = true }) => {
+  const { tokenid } = useRouter().query;
   const { isOpen, onOpen, onClose } = useDisclosure();
+  // If tokenid parameter is same as tokenId, open modal view
+  useEffect(() => {
+    if (String(tokenid) == String(tokenId)) {
+      onOpen();
+    }
+  }, [tokenid, tokenId]);
 
   return (
     <>


### PR DESCRIPTION
fix #276, add code to read tokenid parameter and show modal view of the NFT that has same tokenid.