### PR TITLE
homebrewをつかってnodeのバージョン指定インストール時の考慮不足

### DIFF
--- a/docs/devenv_mac.md
+++ b/docs/devenv_mac.md
@@ -31,6 +31,13 @@ Node.jsは、JavaScriptランタイム環境であり、サーバーサイドで
    ```
    MintRallyではversion16と18にて動作確認をとっています。
    そのためVersion18を指定してインストールしています。
+
+2. Nodeのバージョン指定しているので"keg-only"となっており、PATHが通されていないはずなので以下のコマンドを実行する。
+
+   ```shell
+   'export PATH="/opt/homebrew/opt/node@18/bin:$PATH"' >> ~/.zshrc"
+   ```
+
    
 3. インストール確認
    ```shell


### PR DESCRIPTION
レビュー指摘 https://github.com/hackdays-io/mint-rally/pull/273#issuecomment-1600742364 を取り込んだ際の考慮漏れ

brew install node@XXのようにバージョン指定した場合、
"keg-only" としてインストールされる。

"keg-only" は他のバージョンと競合しないようにPATHが通されない。

その為、PATHを修正する手順を追加した。

---

Consideration oversight when incorporating the review comment (https://github.com/hackdays-io/mint-rally/pull/273#issuecomment-1600742364):

When installing node with a version specified using "brew install node@XX", it is installed as "keg-only".

"Keg-only" installations do not have their paths added to the system's PATH variable to avoid conflicts with other versions.

Therefore, I have added instructions to modify the PATH accordingly.