### PR TITLE
日本語パスワードを使う際の利便性を向上させた

### DIFF
--- a/frontend/src/components/atoms/nft/NFTItem.tsx
+++ b/frontend/src/components/atoms/nft/NFTItem.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Image, Text, useDisclosure } from "@chakra-ui/react";
-import { FC } from "react";
+import { useRouter } from "next/router";
+import { FC, useEffect } from "react";
 import TokenModal from "src/components/molecules/user/TokenModal";
 import { NFT } from "types/NFT";
 import { ipfs2http } from "utils/ipfs2http";
@@ -11,7 +12,14 @@ type Props = {
 };
 
 export const NFTItem: FC<Props> = ({ nft, tokenId, shareURL = true }) => {
+  const { tokenid } = useRouter().query;
   const { isOpen, onOpen, onClose } = useDisclosure();
+  // If tokenid parameter is same as tokenId, open modal view
+  useEffect(() => {
+    if (String(tokenid) == String(tokenId)) {
+      onOpen();
+    }
+  }, [tokenid, tokenId]);
 
   return (
     <>

--- a/frontend/src/components/organisms/nft/MintForm.tsx
+++ b/frontend/src/components/organisms/nft/MintForm.tsx
@@ -17,8 +17,6 @@ import { useMintParticipateNFT } from "src/hooks/useMintNFT";
 import { Event } from "types/Event";
 import { ipfs2http } from "utils/ipfs2http";
 import { useReward } from "react-rewards";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 import { useWallet } from "@thirdweb-dev/react";
 
 type Props = {
@@ -50,13 +48,7 @@ export const MintForm: FC<Props> = ({ event, address }) => {
   }, [status, mintedNFT]);
 
   const [enteredSecretPhrase, setEnteredSecretPhrase] = useState("");
-  const [passwordType, setPasswordType] = useState("password");
 
-  const togglePasswordVisibility = () => {
-    setPasswordType((prevType) =>
-      prevType === "password" ? "text" : "password"
-    );
-  };
 
   const claimMint = async () => {
     if (!event) return;
@@ -88,32 +80,12 @@ export const MintForm: FC<Props> = ({ event, address }) => {
           >
             <Input
               variant="outline"
-              type={passwordType}
+              type="password"
               value={enteredSecretPhrase}
               onChange={(e) => setEnteredSecretPhrase(e.target.value)}
               pr={10}
               placeholder={t.INPUT_SECRET_PHRASE}
             />
-            <Box
-              as="span"
-              position="absolute"
-              right={3}
-              top={2}
-              zIndex={5}
-              cursor="pointer"
-            >
-              {passwordType === "password" ? (
-                <FontAwesomeIcon
-                  onClick={togglePasswordVisibility}
-                  icon={faEye}
-                />
-              ) : (
-                <FontAwesomeIcon
-                  onClick={togglePasswordVisibility}
-                  icon={faEyeSlash}
-                />
-              )}
-            </Box>
           </Box>
           <Button
             width={{ base: "100%", md: "48%" }}

--- a/frontend/src/components/organisms/nft/MintForm.tsx
+++ b/frontend/src/components/organisms/nft/MintForm.tsx
@@ -80,7 +80,7 @@ export const MintForm: FC<Props> = ({ event, address }) => {
           >
             <Input
               variant="outline"
-              type="password"
+              type="text"
               value={enteredSecretPhrase}
               onChange={(e) => setEnteredSecretPhrase(e.target.value)}
               pr={10}


### PR DESCRIPTION
改善策です。

参加者がMintする際に日本語パスワード(合言葉)を入力しようとすると
入力欄が伏せ字モード(type=password)となっている事で、IMEがOFFになってしまい不便です。
※別エディタでパスワードを作ってコピペする等の工夫が必要となって手間

上記事情から2案を比較検討した。

1.  MintRallyとしては日本語パスワードを禁止する。
 イベント企画者がパスワードを登録する画面では、日本語パスワードを入力できないようにする。
2. MintRallyとしては日本語パスワードを許容する。
 イベント参加者がパスワードを入力する画面では、日本語パスワードを入力できるようにする。

チームで検討した結果、案2を採用する事になった。
理由は、日本語パスワードを使いたいという要望がある。
日本語パスワードを使えないようにするためには、イベント企画者のパスワード登録画面で日本語が入力できないようにするのは難しい。(コピペ等の抜け道を全部防ぐのは結構大変)


----

Improvement measures:

When participants attempt to "mint" by entering a Japanese password (secret phrase), it becomes inconvenient due to the input field being in masked mode (type=password), which turns off the IME.
*Additional efforts such as creating a password in a separate editor and copying and pasting are required, which is troublesome.

Based on the above situation, we have compared and considered two proposals:

As MintRally, prohibit Japanese passwords.
In the screen where event planners register passwords, prevent the input of Japanese passwords.
As MintRally, allow Japanese passwords.
In the screen where event participants enter passwords, allow the input of Japanese passwords.
As a result of team discussions, we decided to adopt proposal 2.
The reason is that there is a demand for Japanese passwords.
To prevent the use of Japanese passwords, it is challenging to prevent Japanese input in the password registration screen for event planners (it is quite difficult to prevent all workarounds such as copy and paste).