### PR TITLE
言語切り替えのアイコンを日本語圏以外の人でも直感的にわかるアイコンへ切り替えた。

### DIFF
--- a/frontend/src/components/atoms/LocaleSelector.tsx
+++ b/frontend/src/components/atoms/LocaleSelector.tsx
@@ -2,7 +2,7 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faLanguage } from "@fortawesome/free-solid-svg-icons";
+import { faGlobe } from "@fortawesome/free-solid-svg-icons";
 
 const LocaleSelector = () => {
   const router = useRouter();
@@ -11,7 +11,7 @@ const LocaleSelector = () => {
     <>
       <Menu>
         <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
-          <FontAwesomeIcon icon={faLanguage} />
+          <FontAwesomeIcon icon={faGlobe} />
         </MenuButton>
         <MenuList>
           {otherLocales.map((locale) => {


### PR DESCRIPTION
We have switched the language toggle icon to one that is intuitively understandable, not only for Japanese speakers but also for people outside of the Japanese-speaking regions.
https://github.com/hackdays-io/mint-rally/issues/149