### PR TITLE
Changed link colors for clarity

### DIFF
--- a/frontend/src/components/atoms/events/OrganizerInfo.tsx
+++ b/frontend/src/components/atoms/events/OrganizerInfo.tsx
@@ -1,4 +1,13 @@
-import { Spinner, Table, Tbody, Td, Text, Th, Tr } from "@chakra-ui/react";
+import {
+  Link as ChakraUILink,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Tr,
+} from "@chakra-ui/react";
 import Link from "next/link";
 import { FC, useMemo } from "react";
 import { useEventGroups } from "src/hooks/useEvent";
@@ -35,9 +44,9 @@ export const OrganizerRows: FC<Props> = ({ eventgroupid }: Props) => {
             </Th>
             <Td pl={0} overflowWrap="anywhere">
               <Link href={`/event-groups/${findgroup.groupId}`}>
-                <a>
+                <ChakraUILink color="mint.subtle1">
                   <Text fontSize="16px">{findgroup.name}</Text>
-                </a>
+                </ChakraUILink>
               </Link>
             </Td>
           </Tr>

--- a/frontend/src/components/atoms/web3/ENSName.tsx
+++ b/frontend/src/components/atoms/web3/ENSName.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { FC } from "react";
 import { useEnsName } from "../../../hooks/useEnsName";
-import { Tooltip, position, Text } from "@chakra-ui/react";
+import { Tooltip, Link as ChakraUILink } from "@chakra-ui/react";
 import { User } from "react-feather";
 type Props = {
   address: string;
@@ -20,7 +20,7 @@ const ENSName: FC<Props> = ({
     <>
       {enableUserLink ? (
         <Link href={`/users/${address}`}>
-          <a>{ensName || address}</a>
+          <ChakraUILink color="mint.subtle1">{ensName || address}</ChakraUILink>
         </Link>
       ) : (
         <>{ensName || address}</>

--- a/frontend/src/pages/nfts/[tokenid].tsx
+++ b/frontend/src/pages/nfts/[tokenid].tsx
@@ -3,7 +3,6 @@ import {
   Container,
   Flex,
   Heading,
-  Link,
   Table,
   Tbody,
   Tr,


### PR DESCRIPTION
<img width="1174" alt="スクリーンショット 2023-08-18 23 25 35" src="https://github.com/hackdays-io/mint-rally/assets/701242/fb8c2078-5b16-4434-91bb-baddae30cd47">

The color of the text and links are the same, so it was difficult to distinguish between them. There are other link descriptions, but for the time being, I have focused on the components on the NFT screen.