### PR TITLE
Issue #360--Change Twitter icon to X

### DIFF
--- a/frontend/src/components/atoms/icons/TwitterXicon/TwitterXicon.tsx
+++ b/frontend/src/components/atoms/icons/TwitterXicon/TwitterXicon.tsx
@@ -1,12 +1,14 @@
 import { Icon } from '@chakra-ui/react';
 import { FC } from 'react';
 
-export const XIcon: FC = () => (
+interface XIconProps {
+    color?: 'black' | 'white';
+  }
+
+export const XIcon: FC<XIconProps> = ({ color = 'black' }) => (
   <Icon height="100%" width="100%" maxWidth="20px">
-    <svg height="100%" width="100%" viewBox="0 0 1668.56 1221.19" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M485.39,356.79l230.07,307.62L483.94,914.52h52.11l202.7-218.98l163.77,218.98h177.32
-        L836.82,589.6l215.5-232.81h-52.11L813.54,558.46L662.71,356.79H485.39z M562.02,395.17h81.46l359.72,480.97h-81.46L562.02,395.17
-        z" fill="white" />
+    <svg height="100%" width="100%" viewBox="0 0 1200 1227" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" fill={color} />
     </svg>
   </Icon>
 );

--- a/frontend/src/components/atoms/icons/TwitterXicon/TwitterXicon.tsx
+++ b/frontend/src/components/atoms/icons/TwitterXicon/TwitterXicon.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@chakra-ui/react';
 import { FC } from 'react';
 
-export const NewIcon: FC = () => (
+export const XIcon: FC = () => (
   <Icon height="100%" width="100%" maxWidth="20px">
     <svg height="100%" width="100%" viewBox="0 0 1668.56 1221.19" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M485.39,356.79l230.07,307.62L483.94,914.52h52.11l202.7-218.98l163.77,218.98h177.32

--- a/frontend/src/components/atoms/icons/TwitterXicon/TwitterXicon.tsx
+++ b/frontend/src/components/atoms/icons/TwitterXicon/TwitterXicon.tsx
@@ -1,0 +1,12 @@
+import { Icon } from '@chakra-ui/react';
+import { FC } from 'react';
+
+export const NewIcon: FC = () => (
+  <Icon height="100%" width="100%" maxWidth="20px">
+    <svg height="100%" width="100%" viewBox="0 0 1668.56 1221.19" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M485.39,356.79l230.07,307.62L483.94,914.52h52.11l202.7-218.98l163.77,218.98h177.32
+        L836.82,589.6l215.5-232.81h-52.11L813.54,558.46L662.71,356.79H485.39z M562.02,395.17h81.46l359.72,480.97h-81.46L562.02,395.17
+        z" fill="white" />
+    </svg>
+  </Icon>
+);

--- a/frontend/src/components/atoms/nft/ShareButtons.tsx
+++ b/frontend/src/components/atoms/nft/ShareButtons.tsx
@@ -40,7 +40,7 @@ export const ShareButtons: FC<Props> = ({
       <Text mb={1} mr={5}>
         Share on
       </Text>
-      {twitter && (
+      {/* {twitter && (
         <TwitterShareButton
           url={shareUrl}
           title={`Check out my NFT on Mintrally!`}
@@ -49,7 +49,20 @@ export const ShareButtons: FC<Props> = ({
         >
           <TwitterIcon size={32} round />
         </TwitterShareButton>
+      )} */}
+      
+      {/* TwitterX icon  */}
+      {twitterX && (
+        <TwitterShareButton
+        url={shareUrl}
+        title={`Check out my NFT on Mintrally!`}
+        hashtags={["MintRally"]}
+        style={{ marginRight: "5px" }}
+        >
+        <XIcon color="black" />
+      </TwitterShareButton>
       )}
+
       {facebook && (
         <FacebookShareButton
           url={shareUrl}

--- a/frontend/src/components/atoms/nft/ShareButtons.tsx
+++ b/frontend/src/components/atoms/nft/ShareButtons.tsx
@@ -9,6 +9,8 @@ import {
 } from "next-share";
 import { CopyIcon } from "@chakra-ui/icons";
 import { useRouter } from "next/router";
+import { XIcon } from '../icons/TwitterXicon/TwitterXIcon.';
+
 
 type Props = {
   tokenId: number;


### PR DESCRIPTION
I followed OpenseaIcon as a template and saved the component under icons in its own folder. 

Twitter.com's brand page has the X icon in white and black. I used their SVG and thought switching between black and white would be most beneficial. There are different versions of the X icon online (an x in a circle was a common one I found, but it wasn't available. on Twitter.com, so I'm wondering if it is official). I can, of course, update this to make those versions available in the component. 

I downloaded the SVG from here https://about.twitter.com/en/who-we-are/brand-toolkit

In ShareButton.tsx I wrapped IconX.tsx in the TwitterShare component from Next-share and commented out the old twitter icon. 