### PR TITLE
Feature/324 pausable

### DIFF
--- a/hardhat/contracts/Event.sol
+++ b/hardhat/contracts/Event.sol
@@ -4,11 +4,10 @@ pragma solidity ^0.8.4;
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "./IMintNFT.sol";
 import "hardhat/console.sol";
 
-contract EventManager is OwnableUpgradeable, PausableUpgradeable {
+contract EventManager is OwnableUpgradeable {
     struct Group {
         uint256 groupId;
         address ownerAddress;
@@ -45,6 +44,8 @@ contract EventManager is OwnableUpgradeable, PausableUpgradeable {
     // max mint limit
     uint256 private maxMintLimit;
 
+    bool private isPaused;
+
     modifier onlyGroupOwner(uint256 _groupId) {
         bool _isGroupOwner = false;
         for (uint256 _i = 0; _i < ownGroupIds[msg.sender].length; _i++) {
@@ -53,6 +54,11 @@ contract EventManager is OwnableUpgradeable, PausableUpgradeable {
             }
         }
         require(_isGroupOwner, "You are not group owner");
+        _;
+    }
+
+    modifier whenNotPaused() {
+        require(!paused(), "Paused");
         _;
     }
 
@@ -77,6 +83,8 @@ contract EventManager is OwnableUpgradeable, PausableUpgradeable {
 
     event CreateGroup(address indexed owner, uint256 groupId);
     event CreateEvent(address indexed owner, uint256 eventId);
+    event Paused(address account);
+    event Unpaused(address account);
 
     // Currently, reinitializer(2) was executed as constructor.
     function initialize(
@@ -249,11 +257,17 @@ contract EventManager is OwnableUpgradeable, PausableUpgradeable {
         return isGroupOwner;
     }
 
+    function paused() public view returns (bool) {
+        return isPaused;
+    }
+
     function pause() public onlyOwner {
-        _pause();
+        isPaused = true;
+        emit Paused(msg.sender);
     }
 
     function unpause() public onlyOwner {
-        _unpause();
+        isPaused = false;
+        emit Unpaused(msg.sender);
     }
 }

--- a/hardhat/test/EventManager.ts
+++ b/hardhat/test/EventManager.ts
@@ -82,7 +82,7 @@ describe("EventManager", function () {
       // revert if paused
       await eventManager.connect(organizer).pause();
       await expect(eventManager.createGroup("group1")).to.be.revertedWith(
-        "Pausable: paused"
+        "Paused"
       );
       await eventManager.connect(organizer).unpause();
 
@@ -108,7 +108,7 @@ describe("EventManager", function () {
           publicInputCalldata[0],
           attributes
         )
-      ).to.be.revertedWith("Pausable: paused");
+      ).to.be.revertedWith("Paused");
       await eventManager.connect(organizer).unpause();
 
       // revert if MintNFT is paused
@@ -124,7 +124,7 @@ describe("EventManager", function () {
           publicInputCalldata[0],
           attributes
         )
-      ).to.be.revertedWith("Pausable: paused");
+      ).to.be.revertedWith("Paused");
       await mintNFT.connect(organizer).unpause();
 
       const txn2 = await eventManager.createEventRecord(
@@ -427,10 +427,14 @@ describe("EventManager", function () {
     it("Should pause and unpause", async () => {
       expect(await eventManager.paused()).to.equal(false);
 
-      await eventManager.connect(organizer).pause();
+      await expect(eventManager.connect(organizer).pause())
+        .to.emit(eventManager, "Paused")
+        .withArgs(organizer.address);
       expect(await eventManager.paused()).to.equal(true);
 
-      await eventManager.connect(organizer).unpause();
+      await expect(eventManager.connect(organizer).unpause())
+        .to.emit(eventManager, "Unpaused")
+        .withArgs(organizer.address);
       expect(await eventManager.paused()).to.equal(false);
     });
 

--- a/hardhat/test/EventManager.ts
+++ b/hardhat/test/EventManager.ts
@@ -95,7 +95,7 @@ describe("EventManager", function () {
       const eventRecordsBeforeCreate = await eventManager.getEventRecords(0, 0);
       expect(eventRecordsBeforeCreate.length).to.equal(0);
 
-      // revert if paused
+      // revert if EventManager is paused
       await eventManager.connect(organizer).pause();
       await expect(
         eventManager.createEventRecord(
@@ -110,6 +110,22 @@ describe("EventManager", function () {
         )
       ).to.be.revertedWith("Pausable: paused");
       await eventManager.connect(organizer).unpause();
+
+      // revert if MintNFT is paused
+      await mintNFT.connect(organizer).pause();
+      await expect(
+        eventManager.createEventRecord(
+          groupsAfterCreate[0].groupId.toNumber(),
+          "event1",
+          "event1 description",
+          "2022-07-3O",
+          100,
+          false,
+          publicInputCalldata[0],
+          attributes
+        )
+      ).to.be.revertedWith("Pausable: paused");
+      await mintNFT.connect(organizer).unpause();
 
       const txn2 = await eventManager.createEventRecord(
         groupsAfterCreate[0].groupId.toNumber(),

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -591,7 +591,7 @@ describe("Pause and Unpause", () => {
         attributes
       );
     await createEventTxn.wait();
-    const eventsList = await eventManager.getEventRecords();
+    const eventsList = await eventManager.getEventRecords(0, 0);
     createdEventIds.push(eventsList[0].eventRecordId.toNumber());
   });
 

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -127,7 +127,7 @@ describe("MintNFT", function () {
         mintNFT
           .connect(participant1)
           .mintParticipateNFT(createdGroupId, createdEventIds[0], proofCalldata)
-      ).to.be.revertedWith("Pausable: paused");
+      ).to.be.revertedWith("Paused");
       await mintNFT.connect(organizer).unpause();
     });
   });
@@ -154,7 +154,7 @@ describe("MintNFT", function () {
       // revert if paused
       await mintNFT.connect(organizer).pause();
       await expect(mintNFT.connect(organizer).burn(0)).to.be.revertedWith(
-        "Pausable: paused"
+        "Paused"
       );
       await mintNFT.connect(organizer).unpause();
 
@@ -411,7 +411,7 @@ describe("mint locked flag", () => {
     await mintNFT.connect(organizer).pause();
     await expect(
       mintNFT.connect(organizer).changeMintLocked(1, false)
-    ).to.be.revertedWith("Pausable: paused");
+    ).to.be.revertedWith("Paused");
     await mintNFT.connect(organizer).unpause();
   });
 });
@@ -514,7 +514,7 @@ describe("reset secret phrase", () => {
     await mintNFT.connect(organizer).pause();
     await expect(
       mintNFT.connect(organizer).resetSecretPhrase(1, newProofCalldata)
-    ).to.be.revertedWith("Pausable: paused");
+    ).to.be.revertedWith("Paused");
     await mintNFT.connect(organizer).unpause();
   });
 });
@@ -596,24 +596,28 @@ describe("Pause and Unpause", () => {
   });
 
   it("should pause and unpause", async () => {
-    expect(await eventManager.paused()).to.equal(false);
+    expect(await mintNFT.paused()).to.equal(false);
 
-    await eventManager.connect(organizer).pause();
-    expect(await eventManager.paused()).to.equal(true);
+    await expect(mintNFT.connect(organizer).pause())
+      .to.emit(mintNFT, "Paused")
+      .withArgs(organizer.address);
+    expect(await mintNFT.paused()).to.equal(true);
 
-    await eventManager.connect(organizer).unpause();
-    expect(await eventManager.paused()).to.equal(false);
+    await expect(mintNFT.connect(organizer).unpause())
+      .to.emit(mintNFT, "Unpaused")
+      .withArgs(organizer.address);
+    expect(await mintNFT.paused()).to.equal(false);
   });
 
   it("should not pause if not owner", async () => {
-    await expect(eventManager.connect(participant1).pause()).to.be.revertedWith(
+    await expect(mintNFT.connect(participant1).pause()).to.be.revertedWith(
       "Ownable: caller is not the owner"
     );
   });
 
   it("should not unpause if not owner", async () => {
-    await expect(
-      eventManager.connect(participant1).unpause()
-    ).to.be.revertedWith("Ownable: caller is not the owner");
+    await expect(mintNFT.connect(participant1).unpause()).to.be.revertedWith(
+      "Ownable: caller is not the owner"
+    );
   });
 });


### PR DESCRIPTION
Close: https://github.com/hackdays-io/mint-rally/issues/324

# 対応内容
- MintNFT と EventManger に Pausable の機能を追加
  - Pausable の実装は OpenZeppelin のものを参考に実装
  - https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/3d38f9a8b00caa9901508b3c660ae10ec5076f23/contracts/utils/PausableUpgradeable.sol
- 修正に合わせてテストを追加
- 最新の staging ブランチから生やすように git rebase を実施済

# 確認
- ローカルでのテスト実行が通ることを確認
- ローカルにて最新コードでアップグレードを確認

<details>
<summary>アップグレード確認</summary>

```
>> git br -v
  feature/324-pausable 47b682f fix merge conflict of MintNFT test
* staging              28f8965 Merge pull request #391 from hackdays-io/feature/378-add-pagenation

[2023/09/05 10:54:20] mint-rally/hardhat on  staging [!?] via  v18.16.0
>> yarn deploy:local
yarn run v1.22.17
$ npx hardhat run scripts/deploy_local.ts --network local
Generating typings for: 2 artifacts in dir: typechain for target: ethers-v5
Successfully generated 7 typings!
Compiled 2 Solidity files successfully
forwarder address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
secretPhraseVerifier address: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
mintNFT address: 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
eventManager address: 0x0165878A594ca255338adfa4d48449f69242Eb8F

----------
For frontEnd
----------
NEXT_PUBLIC_FORWARDER_ADDRESS=0x5FbDB2315678afecb367f032d93F642f64180aa3
NEXT_PUBLIC_CONTRACT_SECRET_PHRASE_VERIFIER=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
NEXT_PUBLIC_CONTRACT_MINT_NFT_MANAGER=0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
NEXT_PUBLIC_CONTRACT_EVENT_MANAGER=0x0165878A594ca255338adfa4d48449f69242Eb8F
✨  Done in 7.18s.

>> git co feature/324-pausable
Switched to branch 'feature/324-pausable'

>> git br -v
* feature/324-pausable 47b682f fix merge conflict of MintNFT test
  staging              28f8965 Merge pull request #391 from hackdays-io/feature/378-add-pagenation

>> npx hardhat run scripts/upgrades/v1.2.0/upgrade_local.ts --network local
Generating typings for: 2 artifacts in dir: typechain for target: ethers-v5
Successfully generated 7 typings!
Compiled 2 Solidity files successfully
mintNFT address: 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
eventManager address: 0x0165878A594ca255338adfa4d48449f69242Eb8F
secretPhraseVerifier address: 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318
```

</details>

