### PR TITLE
Feature/395 disable magiclink for non mtx

### DIFF
--- a/frontend/src/components/atoms/events/GetWithMagicLinkButton.tsx
+++ b/frontend/src/components/atoms/events/GetWithMagicLinkButton.tsx
@@ -1,4 +1,11 @@
-import { Button, FormLabel, HStack, Input, Stack } from "@chakra-ui/react";
+import {
+  Button,
+  FormLabel,
+  HStack,
+  Input,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
 import { faArrowLeft, faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useConnect, useConnectionStatus } from "@thirdweb-dev/react";
@@ -8,9 +15,10 @@ import { chainId, useWeb3WalletConfig } from "src/libs/web3Config";
 
 type Props = {
   selected: (selected: boolean) => void;
+  disabled?: boolean;
 };
 
-const GetWithMagicLinkButton: FC<Props> = ({ selected }) => {
+const GetWithMagicLinkButton: FC<Props> = ({ selected, disabled }) => {
   const { t } = useLocale();
   const { magicLinkConfig } = useWeb3WalletConfig();
   const connect = useConnect();
@@ -33,21 +41,25 @@ const GetWithMagicLinkButton: FC<Props> = ({ selected }) => {
   return (
     <>
       {!isSelected ? (
-        <Button
-          w={280}
-          leftIcon={<FontAwesomeIcon icon={faEnvelope} />}
-          style={{
-            fontWeight: "bold",
-            backgroundColor: "#562406",
-            color: "#fff",
-          }}
-          onClick={() => {
-            setSelected(true);
-            selected(true);
-          }}
-        >
-          {t.GET_NFT_USING_EMAIL}
-        </Button>
+        <>
+          <Button
+            w={280}
+            leftIcon={<FontAwesomeIcon icon={faEnvelope} />}
+            style={{
+              fontWeight: "bold",
+              backgroundColor: "#562406",
+              color: "#fff",
+            }}
+            onClick={() => {
+              setSelected(true);
+              selected(true);
+            }}
+            disabled={disabled}
+          >
+            {t.GET_NFT_USING_EMAIL}
+          </Button>
+          {disabled && <Text>{t.NOT_ALLOWED_MAGIC_LINK}</Text>}
+        </>
       ) : (
         <>
           <FormLabel color="yellow.900">

--- a/frontend/src/components/atoms/events/MintNFTLoginRequired.tsx
+++ b/frontend/src/components/atoms/events/MintNFTLoginRequired.tsx
@@ -9,12 +9,14 @@ type Props = {
   children: ReactNode;
   requiredChainID: number;
   forbiddenText: string;
+  allowMagicLink: boolean;
 };
 
 const MintNFTLoginRequired: FC<Props> = ({
   children,
   requiredChainID,
   forbiddenText,
+  allowMagicLink,
 }) => {
   const address = useAddress();
   const chainId = useChainId()!;
@@ -44,7 +46,7 @@ const MintNFTLoginRequired: FC<Props> = ({
               alt="civitan"
             />
           </HStack>
-          <SelectMintWallet />
+          <SelectMintWallet allowMagicLink={allowMagicLink} />
         </Box>
       ) : chainId !== requiredChainID ? (
         <Box

--- a/frontend/src/components/atoms/events/SelectMintWallet.tsx
+++ b/frontend/src/components/atoms/events/SelectMintWallet.tsx
@@ -4,8 +4,11 @@ import { Text } from "@chakra-ui/react";
 import { useLocale } from "src/hooks/useLocale";
 import GetWithMetamaskButton from "./GetWithMetamaskButton";
 import GetWithMagicLinkButton from "./GetWithMagicLinkButton";
+type Props = {
+  allowMagicLink: boolean;
+};
 
-const SelectMintWallet: FC = () => {
+const SelectMintWallet: FC<Props> = ({ allowMagicLink }) => {
   const [magicLinkSelected, setMagicLinkSelected] = useState<boolean>(false);
   const { t } = useLocale();
 
@@ -19,7 +22,10 @@ const SelectMintWallet: FC = () => {
           <GetWithMetamaskButton />
         </>
       )}
-      <GetWithMagicLinkButton selected={setMagicLinkSelected} />
+      <GetWithMagicLinkButton
+        selected={setMagicLinkSelected}
+        disabled={!allowMagicLink}
+      />
     </VStack>
   );
 };

--- a/frontend/src/components/atoms/web3/LoginRequired.tsx
+++ b/frontend/src/components/atoms/web3/LoginRequired.tsx
@@ -2,7 +2,6 @@ import { Box, Button, HStack, Heading, Text } from "@chakra-ui/react";
 import { FC, ReactNode, useState } from "react";
 import { useAddress, useChainId, useSwitchChain } from "@thirdweb-dev/react";
 import { useLocale } from "../../../hooks/useLocale";
-import SelectMintWallet from "src/components/molecules/web3/SelectMintWallet";
 import Image from "next/image";
 import SelectConnectWallet from "src/components/molecules/web3/SelectConnectWallet";
 

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -17,7 +17,8 @@ export default {
   CONNECT_WITH_EMAIL: "Connect with Email",
   CONNECT_WITH_SAFE: "Connect with Safe",
   INPUT_SAFE_WALLET_ADDRESS: "Input Safe Wallet Address",
-  NOT_ALLOWED_MAGIC_LINK: "This event's NFT is not allowed to get via email.",
+  NOT_ALLOWED_MAGIC_LINK: "This event is not supported email login.",
+  MAGICLINK_IS_NOT_SUPPORTED_USE_OTHERS: "This event is not supported email login. Please logout and select another wallet.",
   // NFT
   NFT_NAME: "NFT Name",
   NFT_DESC: "NFT Description",

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -17,6 +17,7 @@ export default {
   CONNECT_WITH_EMAIL: "Connect with Email",
   CONNECT_WITH_SAFE: "Connect with Safe",
   INPUT_SAFE_WALLET_ADDRESS: "Input Safe Wallet Address",
+  NOT_ALLOWED_MAGIC_LINK: "This event's NFT is not allowed to get via email.",
   // NFT
   NFT_NAME: "NFT Name",
   NFT_DESC: "NFT Description",

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -22,6 +22,7 @@ export default {
   CONNECT_WITH_EMAIL: "メールアドレスで接続",
   CONNECT_WITH_SAFE: "Safeで接続",
   INPUT_SAFE_WALLET_ADDRESS: "Safeのウォレットアドレスを入力",
+  NOT_ALLOWED_MAGIC_LINK: "このイベントのNFTはメールアドレスでは受け取れません。",
   // Event group index
   NO_EVENTS_AVAILABLE: "イベントがありません",
   CREATE_NEW_EVENT_GROUP: "イベントグループを作成",

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -22,7 +22,8 @@ export default {
   CONNECT_WITH_EMAIL: "メールアドレスで接続",
   CONNECT_WITH_SAFE: "Safeで接続",
   INPUT_SAFE_WALLET_ADDRESS: "Safeのウォレットアドレスを入力",
-  NOT_ALLOWED_MAGIC_LINK: "このイベントのNFTはメールアドレスでは受け取れません。",
+  NOT_ALLOWED_MAGIC_LINK: "このイベントはメールアドレスログインをサポートしていません。",
+  MAGICLINK_IS_NOT_SUPPORTED_USE_OTHERS: "このイベントはメールアドレスログインをサポートしていません。ログアウトの上違うWalletを選択してください。",
   // Event group index
   NO_EVENTS_AVAILABLE: "イベントがありません",
   CREATE_NEW_EVENT_GROUP: "イベントグループを作成",

--- a/frontend/src/pages/events/[eventid].tsx
+++ b/frontend/src/pages/events/[eventid].tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { FC, Fragment, useMemo } from "react";
 import { useLocale } from "../../hooks/useLocale";
 import { MintForm } from "src/components/organisms/nft/MintForm";
-import { useAddress } from "@thirdweb-dev/react";
+import { useAddress, useWallet, magicLink } from "@thirdweb-dev/react";
 import {
   useGetOwnedNFTByAddress,
   useIsHoldingEventNftByAddress,
@@ -21,6 +21,8 @@ import EventEditSection from "src/components/organisms/EventEditSection";
 
 const MintNFTSection: FC<{ event: Event.EventRecord }> = ({ event }) => {
   const address = useAddress();
+  const walletInstance = useWallet();
+  const { t } = useLocale();
   const { isHoldingEventNft, isLoading } = useIsHoldingEventNftByAddress(
     address,
     event.eventRecordId
@@ -34,7 +36,6 @@ const MintNFTSection: FC<{ event: Event.EventRecord }> = ({ event }) => {
         nft.traits.EventGroupId === event?.groupId.toString()
     );
   }, [nfts, address]);
-
   return (
     <>
       {isLoading || checkHoldingNFTs || !address ? (
@@ -59,7 +60,11 @@ const MintNFTSection: FC<{ event: Event.EventRecord }> = ({ event }) => {
           py={{ md: 8, base: 5 }}
           px={{ md: 10, base: 5 }}
         >
-          <MintForm event={event} address={address} />
+          {walletInstance?.walletId == "magicLink" && !event.useMtx ? (
+            <Text>{t.MAGICLINK_IS_NOT_SUPPORTED_USE_OTHERS}</Text>
+          ) : (
+            <MintForm event={event} address={address} />
+          )}
         </Box>
       )}
     </>
@@ -72,7 +77,6 @@ const Event: FC = () => {
   const { event, isLoading } = useEventById(Number(eventid));
 
   const { t } = useLocale();
-
   return (
     <>
       <Container maxW={800} py={6} pb="120px">
@@ -108,7 +112,7 @@ const Event: FC = () => {
             <MintNFTLoginRequired
               requiredChainID={+process.env.NEXT_PUBLIC_CHAIN_ID!}
               forbiddenText={t.SIGN_IN_TO_GET_NFT}
-              allowMagicLink={!event.useMtx}
+              allowMagicLink={event.useMtx == true}
             >
               <MintNFTSection event={event} />
               <EventEditSection event={event} />

--- a/frontend/src/pages/events/[eventid].tsx
+++ b/frontend/src/pages/events/[eventid].tsx
@@ -108,6 +108,7 @@ const Event: FC = () => {
             <MintNFTLoginRequired
               requiredChainID={+process.env.NEXT_PUBLIC_CHAIN_ID!}
               forbiddenText={t.SIGN_IN_TO_GET_NFT}
+              allowMagicLink={!event.useMtx}
             >
               <MintNFTSection event={event} />
               <EventEditSection event={event} />

--- a/frontend/src/pages/events/[eventid].tsx
+++ b/frontend/src/pages/events/[eventid].tsx
@@ -1,4 +1,4 @@
-import { Heading, Spinner, Text, Container, Box, Flex } from "@chakra-ui/react";
+import { Heading, Spinner, Text, Container, Box } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { FC, Fragment, useMemo } from "react";
 import { useLocale } from "../../hooks/useLocale";


### PR DESCRIPTION
close #395 

1. イベントページが肩代わり無しの場合、MagicLink のログインボタンを比活性にした

![Screenshot 2023-09-07 at 16 06 45](https://github.com/hackdays-io/mint-rally/assets/16509/8b3a1c09-0e12-4583-8192-67a2b3d0590d)

2. すでにMagicLinkでログインしている場合、肩代わり無しイベントではフォームを非表示にした

![image](https://github.com/hackdays-io/mint-rally/assets/16509/29b72673-88ba-4526-bdb6-b6ca08f00a90)