### PR TITLE
Feature/324 pausable 2

### DIFF
--- a/hardhat/contracts/IOperationController.sol
+++ b/hardhat/contracts/IOperationController.sol
@@ -1,0 +1,6 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IOperationController {
+    function paused() external view returns (bool);
+}

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -247,7 +247,7 @@ contract MintNFT is
         return remainingEventNftCount[_eventId];
     }
 
-    function burn(uint256 tokenId) public onlyOwner whenNotPaused {
+    function burn(uint256 tokenId) public onlyOwner {
         _burn(tokenId);
     }
 

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -80,13 +80,8 @@ contract MintNFT is
         IOperationController operationController = IOperationController(
             operationControllerAddr
         );
-        require(!operationController.paused(), "Paused");
+        require(!operationController.paused());
         _;
-    }
-
-    function setOperationControllerAddr(address _operationControllerAddr) public onlyOwner {
-        require(_operationControllerAddr != address(0), "operation controller address is blank");
-        operationControllerAddr = _operationControllerAddr;
     }
 
     // Currently, reinitializer(4) was executed as constructor.
@@ -99,7 +94,7 @@ contract MintNFT is
         __Ownable_init();
         __ERC2771Context_init(address(trustedForwarder));
         secretPhraseVerifierAddr = _secretPhraseVerifierAddr;
-        setOperationControllerAddr(_operationControllerAddr);
+        operationControllerAddr = _operationControllerAddr;
     }
 
     function _msgSender()

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -10,6 +10,7 @@ import "./lib/Hashing.sol";
 import "./ERC2771ContextUpgradeable.sol";
 import "./IEvent.sol";
 import "./ISecretPhraseVerifier.sol";
+import "./IOperationController.sol";
 
 contract MintNFT is
     ERC721EnumerableUpgradeable,
@@ -60,6 +61,8 @@ contract MintNFT is
     // Create a mapping to store NFT holders by event ID
     mapping(uint256 => uint256[]) private tokenIdsByEvent;
 
+    address private operationControllerAddr;
+
     event MintedNFTAttributeURL(address indexed holder, string url);
     event MintLocked(uint256 indexed eventId, bool isLocked);
     event ResetSecretPhrase(address indexed executor, uint256 indexed eventId);
@@ -73,15 +76,30 @@ contract MintNFT is
         _;
     }
 
-    // Currently, reinitializer(3) was executed as constructor.
+    modifier whenNotPaused() {
+        IOperationController operationController = IOperationController(
+            operationControllerAddr
+        );
+        require(!operationController.paused(), "Paused");
+        _;
+    }
+
+    function setOperationControllerAddr(address _operationControllerAddr) public onlyOwner {
+        require(_operationControllerAddr != address(0), "operation controller address is blank");
+        operationControllerAddr = _operationControllerAddr;
+    }
+
+    // Currently, reinitializer(4) was executed as constructor.
     function initialize(
         MinimalForwarderUpgradeable trustedForwarder,
-        address _secretPhraseVerifierAddr
-    ) public reinitializer(3) {
+        address _secretPhraseVerifierAddr,
+        address _operationControllerAddr
+    ) public reinitializer(4) {
         __ERC721_init("MintRally", "MR");
         __Ownable_init();
         __ERC2771Context_init(address(trustedForwarder));
         secretPhraseVerifierAddr = _secretPhraseVerifierAddr;
+        setOperationControllerAddr(_operationControllerAddr);
     }
 
     function _msgSender()
@@ -120,7 +138,7 @@ contract MintNFT is
         uint256 _groupId,
         uint256 _eventId,
         uint256[24] memory _proof
-    ) external {
+    ) external whenNotPaused {
         canMint(_eventId, _proof);
         remainingEventNftCount[_eventId] = remainingEventNftCount[_eventId] - 1;
 
@@ -184,7 +202,7 @@ contract MintNFT is
     function changeMintLocked(
         uint256 _eventId,
         bool _locked
-    ) external onlyGroupOwner(_eventId) {
+    ) external onlyGroupOwner(_eventId) whenNotPaused {
         isMintLocked[_eventId] = _locked;
         emit MintLocked(_eventId, _locked);
     }
@@ -192,7 +210,7 @@ contract MintNFT is
     function resetSecretPhrase(
         uint256 _eventId,
         bytes32 _secretPhrase
-    ) external onlyGroupOwner(_eventId) {
+    ) external onlyGroupOwner(_eventId) whenNotPaused {
         eventSecretPhrases[_eventId] = _secretPhrase;
         emit ResetSecretPhrase(_msgSender(), _eventId);
     }
@@ -214,7 +232,7 @@ contract MintNFT is
         uint256 _mintLimit,
         bytes32 _secretPhrase,
         NFTAttribute[] memory attributes
-    ) external {
+    ) external whenNotPaused {
         require(_msgSender() == eventManagerAddr, "unauthorized");
         remainingEventNftCount[_eventId] = _mintLimit;
         eventSecretPhrases[_eventId] = _secretPhrase;
@@ -234,7 +252,7 @@ contract MintNFT is
         return remainingEventNftCount[_eventId];
     }
 
-    function burn(uint256 tokenId) public onlyOwner {
+    function burn(uint256 tokenId) public onlyOwner whenNotPaused {
         _burn(tokenId);
     }
 

--- a/hardhat/contracts/OperationController.sol
+++ b/hardhat/contracts/OperationController.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+contract OperationController is OwnableUpgradeable, PausableUpgradeable {
+    function initialize() public initializer {
+        __Ownable_init();
+        __Pausable_init();
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/hardhat/scripts/deploy_stg.ts
+++ b/hardhat/scripts/deploy_stg.ts
@@ -4,7 +4,12 @@
 // When running the script with `npx hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
 import { ethers, upgrades } from "hardhat";
-import { MintNFT, EventManager, SecretPhraseVerifier } from "../typechain";
+import {
+  MintNFT,
+  EventManager,
+  SecretPhraseVerifier,
+  OperationController,
+} from "../typechain";
 
 async function main() {
   let mintNFT: MintNFT;

--- a/hardhat/scripts/deploy_stg.ts
+++ b/hardhat/scripts/deploy_stg.ts
@@ -10,6 +10,7 @@ async function main() {
   let mintNFT: MintNFT;
   let eventManager: EventManager;
   let secretPhraseVerifier: SecretPhraseVerifier;
+  let operationController: OperationController;
 
   const ForwarderFactory = await ethers.getContractFactory(
     "MintRallyForwarder"
@@ -23,10 +24,20 @@ async function main() {
   secretPhraseVerifier = await SecretPhraseVerifierFactory.deploy();
   await secretPhraseVerifier.deployed();
 
+  const OperationControllerFactory = await await ethers.getContractFactory(
+    "OperationController"
+  );
+  operationController = await OperationControllerFactory.deploy();
+  await operationController.deployed();
+
   const MintNFTFactory = await ethers.getContractFactory("MintNFT");
   const deployedMintNFT: any = await upgrades.deployProxy(
     MintNFTFactory,
-    [forwarder.address, secretPhraseVerifier.address, []],
+    [
+      forwarder.address,
+      secretPhraseVerifier.address,
+      operationController.address,
+    ],
     {
       initializer: "initialize",
     }
@@ -37,7 +48,12 @@ async function main() {
   const EventManagerFactory = await ethers.getContractFactory("EventManager");
   const deployedEventManager: any = await upgrades.deployProxy(
     EventManagerFactory,
-    [process.env.MUMBAI_RELAYER_ADDRESS, 250000, 1000000],
+    [
+      process.env.MUMBAI_RELAYER_ADDRESS,
+      250000,
+      1000000,
+      operationController.address,
+    ],
     {
       initializer: "initialize",
     }
@@ -50,12 +66,16 @@ async function main() {
 
   console.log("forwarder address:", forwarder.address);
   console.log("secretPhraseVerifier address:", secretPhraseVerifier.address);
+  console.log("operationController address:", operationController.address);
   console.log("mintNFT address:", mintNFT.address);
   console.log("eventManager address:", eventManager.address, "\n");
   console.log("----------\nFor frontEnd\n----------");
   console.log(`NEXT_PUBLIC_FORWARDER_ADDRESS=${forwarder.address}`);
   console.log(
     `NEXT_PUBLIC_CONTRACT_SECRET_PHRASE_VERIFIER=${secretPhraseVerifier.address}`
+  );
+  console.log(
+    `NEXT_PUBLIC_CONTRACT_OPERATION_CONTROLLER=${operationController.address}`
   );
   console.log(`NEXT_PUBLIC_CONTRACT_MINT_NFT_MANAGER=${mintNFT.address}`);
   console.log(`NEXT_PUBLIC_CONTRACT_EVENT_MANAGER=${eventManager.address}`);

--- a/hardhat/scripts/upgrades/v1.2.0/upgrade_local.ts
+++ b/hardhat/scripts/upgrades/v1.2.0/upgrade_local.ts
@@ -6,30 +6,41 @@ async function main() {
 
   const MintNFTFactory = await ethers.getContractFactory("MintNFT");
   const deployedMintNFT: any = await upgrades.upgradeProxy(
-    "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+    "0x0165878A594ca255338adfa4d48449f69242Eb8F",
     MintNFTFactory,
     {
       call: {
         fn: "initialize",
         args: [
-          "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-          "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-          [1, 3, 2],
+          "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9", // forwarder
+          "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9", // secret phrase verifier
+          "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e", // operation controller
         ],
       },
     }
   );
   await deployedMintNFT.deployed();
 
-  // const EventManagerFactory = await ethers.getContractFactory("EventManager");
-  // const deployedEventManager: any = await upgrades.upgradeProxy(
-  //   "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
-  //   EventManagerFactory
-  // );
-  // await deployedEventManager.deployed();
+  const EventManagerFactory = await ethers.getContractFactory("EventManager");
+  const deployedEventManager: any = await upgrades.upgradeProxy(
+    "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+    EventManagerFactory,
+    {
+      call: {
+        fn: "initialize",
+        args: [
+          "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199", // relayer
+          250000,
+          1000000,
+          "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e", // operation controller
+        ],
+      },
+    }
+  );
+  await deployedEventManager.deployed();
 
   console.log("mintNFT address:", deployedMintNFT.address);
-  // console.log("eventManager address:", deployedEventManager.address);
+  console.log("eventManager address:", deployedEventManager.address);
 }
 
 main().catch((error) => {

--- a/hardhat/test/EventManager.ts
+++ b/hardhat/test/EventManager.ts
@@ -2,8 +2,13 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { ethers, upgrades } from "hardhat";
-// eslint-disable-next-line node/no-missing-import
-import { EventManager, MintNFT, SecretPhraseVerifier } from "../typechain";
+import {
+  EventManager,
+  MintNFT,
+  OperationController,
+  SecretPhraseVerifier,
+  // eslint-disable-next-line node/no-missing-import
+} from "../typechain";
 // eslint-disable-next-line node/no-missing-import
 import { generateProof } from "./helper/secret_phrase";
 
@@ -26,6 +31,7 @@ const attributes = [
 describe("EventManager", function () {
   let mintNFT: MintNFT;
   let secretPhraseVerifier: SecretPhraseVerifier;
+  let operationController: OperationController;
   let organizer: SignerWithAddress;
   let participant1: SignerWithAddress;
   let relayer: SignerWithAddress;
@@ -36,6 +42,15 @@ describe("EventManager", function () {
       "SecretPhraseVerifier"
     );
     secretPhraseVerifier = await SecretPhraseVerifierFactory.deploy();
+    const OperationControllerFactory = await ethers.getContractFactory(
+      "OperationController"
+    );
+    const deployedOperationController: any = await upgrades.deployProxy(
+      OperationControllerFactory,
+      { initializer: "initialize" }
+    );
+    operationController = deployedOperationController;
+    await operationController.deployed();
     const MintNFTFactory = await ethers.getContractFactory("MintNFT");
     const deployedMintNFT: any = await upgrades.deployProxy(
       MintNFTFactory,
@@ -60,7 +75,7 @@ describe("EventManager", function () {
       );
       const deployedEventManagerContract: any = await upgrades.deployProxy(
         eventManagerContractFactory,
-        [relayer.address, 250000, 1000000],
+        [relayer.address, 250000, 1000000, operationController.address],
         {
           initializer: "initialize",
         }
@@ -79,6 +94,13 @@ describe("EventManager", function () {
       const groupsBeforeCreate = await eventManager.getGroups();
       expect(groupsBeforeCreate.length).to.equal(0);
 
+      // revert if paused
+      await operationController.connect(organizer).pause();
+      await expect(eventManager.createGroup("group1")).to.be.revertedWith(
+        "Paused"
+      );
+      await operationController.connect(organizer).unpause();
+
       const txn1 = await eventManager.createGroup("group1");
       await txn1.wait();
       const groupsAfterCreate = await eventManager.getGroups();
@@ -87,6 +109,23 @@ describe("EventManager", function () {
 
       const eventRecordsBeforeCreate = await eventManager.getEventRecords(0, 0);
       expect(eventRecordsBeforeCreate.length).to.equal(0);
+
+      // revert if paused
+      await operationController.connect(organizer).pause();
+      await expect(
+        eventManager.createEventRecord(
+          groupsAfterCreate[0].groupId.toNumber(),
+          "event-1",
+          "event-1 description",
+          "2022-07-3O",
+          100,
+          false,
+          publicInputCalldata[0],
+          attributes
+        )
+      ).to.be.revertedWith("Paused");
+
+      await operationController.connect(organizer).unpause();
 
       const txn2 = await eventManager.createEventRecord(
         groupsAfterCreate[0].groupId.toNumber(),
@@ -238,7 +277,7 @@ describe("EventManager", function () {
       );
       const deployedEventManagerContract: any = await upgrades.deployProxy(
         eventManagerContractFactory,
-        [relayer.address, 500000, 1000000],
+        [relayer.address, 500000, 1000000, operationController.address],
         {
           initializer: "initialize",
         }
@@ -288,7 +327,7 @@ describe("EventManager", function () {
       );
       const deployedEventManagerContract: any = await upgrades.deployProxy(
         eventManagerContractFactory,
-        [relayer.address, 250000, 1000000],
+        [relayer.address, 250000, 1000000, operationController.address],
         {
           initializer: "initialize",
         }

--- a/hardhat/test/EventManager.ts
+++ b/hardhat/test/EventManager.ts
@@ -57,6 +57,7 @@ describe("EventManager", function () {
       [
         "0xdCb93093424447bF4FE9Df869750950922F1E30B",
         secretPhraseVerifier.address,
+        operationController.address,
       ],
       {
         initializer: "initialize",

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -236,31 +236,6 @@ describe("MintNFT", function () {
     });
   });
 
-  describe("burn", () => {
-    it("success to burn", async () => {
-      const { proofCalldata } = await generateProof();
-      const mintNftTxn = await mintNFT
-        .connect(participant2)
-        .mintParticipateNFT(createdGroupId, createdEventIds[0], proofCalldata);
-      await mintNftTxn.wait();
-
-      expect(await mintNFT.balanceOf(participant2.address)).equal(1);
-
-      const tokenId = await mintNFT.tokenOfOwnerByIndex(
-        participant2.address,
-        0
-      );
-
-      // revert if paused
-      await operationController.connect(organizer).pause();
-      await expect(mintNFT.connect(organizer).burn(tokenId)).to.be.reverted;
-      await operationController.connect(organizer).unpause();
-
-      await mintNFT.connect(organizer).burn(tokenId);
-      expect(await mintNFT.balanceOf(participant2.address)).equal(0);
-    });
-  });
-
   describe("get NFT holders of the event", () => {
     let mintNFT: MintNFT;
     let eventManager: EventManager;

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -1,7 +1,12 @@
 import { expect } from "chai";
 import { ethers, upgrades } from "hardhat";
-// eslint-disable-next-line node/no-missing-import
-import { MintNFT, EventManager, SecretPhraseVerifier } from "../typechain";
+import {
+  MintNFT,
+  EventManager,
+  SecretPhraseVerifier,
+  OperationController,
+  // eslint-disable-next-line node/no-missing-import
+} from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 // eslint-disable-next-line node/no-missing-import
 import { generateProof, wrongProofCalldata } from "./helper/secret_phrase";
@@ -34,17 +39,36 @@ const deploySecretPhraseVerifier = async () => {
   return await SecretPhraseVerifierFactory.deploy();
 };
 /**
+ * deploy operationController
+ * @returns deployed operationController
+ */
+const deployOperationController = async () => {
+  const OperationControllerFactory = await ethers.getContractFactory(
+    "OperationController"
+  );
+  const deployedOperationController: any = await upgrades.deployProxy(
+    OperationControllerFactory,
+    { initializer: "initialize" }
+  );
+  return deployedOperationController.deployed();
+};
+/**
  * deploy mintNFT
  * @param secretPhraseVerifier
+ * @param operationController
  * @returns deployed mintNFT
  */
-const deployMintNFT = async (secretPhraseVerifier: SecretPhraseVerifier) => {
+const deployMintNFT = async (
+  secretPhraseVerifier: SecretPhraseVerifier,
+  operationController: OperationController
+) => {
   const MintNFTFactory = await ethers.getContractFactory("MintNFT");
   const deployedMintNFT: any = await upgrades.deployProxy(
     MintNFTFactory,
     [
       "0xdCb93093424447bF4FE9Df869750950922F1E30B",
       secretPhraseVerifier.address,
+      operationController.address,
     ],
     {
       initializer: "initialize",
@@ -53,15 +77,19 @@ const deployMintNFT = async (secretPhraseVerifier: SecretPhraseVerifier) => {
   return deployedMintNFT.deployed();
 };
 /**
- * deploy evetManager
+ * deploy eventManager
  * @param relayer address
+ * @param operationController
  * @returns deployed eventManager
  */
-const deployEventManager = async (relayer: SignerWithAddress) => {
+const deployEventManager = async (
+  relayer: SignerWithAddress,
+  operationController: OperationController
+) => {
   const EventManager = await ethers.getContractFactory("EventManager");
   const deployedEventManager: any = await upgrades.deployProxy(
     EventManager,
-    [relayer.address, 250000, 1000000],
+    [relayer.address, 250000, 1000000, operationController.address],
     {
       initializer: "initialize",
     }
@@ -75,11 +103,15 @@ const deployEventManager = async (relayer: SignerWithAddress) => {
  */
 const deployAll = async (relayer: SignerWithAddress) => {
   const secretPhraseVerifier = await deploySecretPhraseVerifier();
-  const mintNFT = await deployMintNFT(secretPhraseVerifier);
-  const eventManager = await deployEventManager(relayer);
+  const operationController = await deployOperationController();
+  const mintNFT = await deployMintNFT(
+    secretPhraseVerifier,
+    operationController
+  );
+  const eventManager = await deployEventManager(relayer, operationController);
   await mintNFT.setEventManagerAddr(eventManager.address);
   await eventManager.setMintNFTAddr(mintNFT.address);
-  return [secretPhraseVerifier, mintNFT, eventManager];
+  return [secretPhraseVerifier, mintNFT, eventManager, operationController];
 };
 type eventGroupParams = {
   groupId: BigNumberish;
@@ -127,6 +159,7 @@ const createEventRecord = async (
 describe("MintNFT", function () {
   let mintNFT: MintNFT;
   let eventManager: EventManager;
+  let operationController: OperationController;
 
   let createdGroupId: number;
   const createdEventIds: number[] = [];
@@ -134,14 +167,16 @@ describe("MintNFT", function () {
   let organizer: SignerWithAddress;
   let participant1: SignerWithAddress;
   let relayer: SignerWithAddress;
+  let participant2: SignerWithAddress;
 
   before(async () => {
-    [organizer, participant1, relayer] = await ethers.getSigners();
+    [organizer, participant1, relayer, participant2] =
+      await ethers.getSigners();
 
     // generate proof
     const { publicInputCalldata } = await generateProof();
     // Deploy all contracts
-    [, mintNFT, eventManager] = await deployAll(relayer);
+    [, mintNFT, eventManager, operationController] = await deployAll(relayer);
     // Create a Group and an Event
     await createGroup(eventManager, "First Group");
     const groupsList = await eventManager.getGroups();
@@ -184,6 +219,45 @@ describe("MintNFT", function () {
           .connect(participant1)
           .mintParticipateNFT(createdGroupId, createdEventIds[0], proofCalldata)
       ).to.be.revertedWith("mint is locked");
+      await mintNFT
+        .connect(organizer)
+        .changeMintLocked(createdEventIds[0], false);
+    });
+
+    it("fail to mint when paused", async () => {
+      const { proofCalldata } = await generateProof();
+      await operationController.pause();
+      await expect(
+        mintNFT
+          .connect(participant1)
+          .mintParticipateNFT(createdGroupId, createdEventIds[0], proofCalldata)
+      ).to.be.reverted;
+      await operationController.unpause();
+    });
+  });
+
+  describe("burn", () => {
+    it("success to burn", async () => {
+      const { proofCalldata } = await generateProof();
+      const mintNftTxn = await mintNFT
+        .connect(participant2)
+        .mintParticipateNFT(createdGroupId, createdEventIds[0], proofCalldata);
+      await mintNftTxn.wait();
+
+      expect(await mintNFT.balanceOf(participant2.address)).equal(1);
+
+      const tokenId = await mintNFT.tokenOfOwnerByIndex(
+        participant2.address,
+        0
+      );
+
+      // revert if paused
+      await operationController.connect(organizer).pause();
+      await expect(mintNFT.connect(organizer).burn(tokenId)).to.be.reverted;
+      await operationController.connect(organizer).unpause();
+
+      await mintNFT.connect(organizer).burn(tokenId);
+      expect(await mintNFT.balanceOf(participant2.address)).equal(0);
     });
   });
 
@@ -481,6 +555,7 @@ describe("nft revolution", () => {
 describe("mint locked flag", () => {
   let mintNFT: MintNFT;
   let eventManager: EventManager;
+  let operationController: OperationController;
 
   let createdGroupId: number;
   const createdEventIds: number[] = [];
@@ -491,7 +566,7 @@ describe("mint locked flag", () => {
 
   before(async () => {
     [organizer, participant1, relayer] = await ethers.getSigners();
-    [, mintNFT, eventManager] = await deployAll(relayer);
+    [, mintNFT, eventManager, operationController] = await deployAll(relayer);
 
     // Create a Group and an Event
     await createGroup(eventManager, "First Group", organizer);
@@ -532,11 +607,19 @@ describe("mint locked flag", () => {
       mintNFT.connect(participant1).changeMintLocked(1, false)
     ).to.be.revertedWith("you are not event group owner");
   });
+
+  it("should not change if paused", async () => {
+    await operationController.connect(organizer).pause();
+    await expect(mintNFT.connect(organizer).changeMintLocked(1, false)).to.be
+      .reverted;
+    await operationController.connect(organizer).unpause();
+  });
 });
 
 describe("reset secret phrase", () => {
   let mintNFT: MintNFT;
   let eventManager: EventManager;
+  let operationController: OperationController;
 
   let createdGroupId: number;
   const createdEventIds: number[] = [];
@@ -550,7 +633,7 @@ describe("reset secret phrase", () => {
   before(async () => {
     [organizer, participant1, relayer] = await ethers.getSigners();
     // deploy all contracts
-    [, mintNFT, eventManager] = await deployAll(relayer);
+    [, mintNFT, eventManager, operationController] = await deployAll(relayer);
     // generate proof
     const { publicInputCalldata } = await generateProof();
     correctProofCalldata = publicInputCalldata[0];
@@ -591,5 +674,15 @@ describe("reset secret phrase", () => {
     await expect(
       mintNFT.connect(participant1).resetSecretPhrase(1, newProofCalldata)
     ).to.be.revertedWith("you are not event group owner");
+  });
+
+  it("cannot change if paused", async () => {
+    const newProofCalldata =
+      "0x1f376ca3150d51a164c711287cff6e77e2127d635a1534b41d5624472f000000";
+    await operationController.connect(organizer).pause();
+    await expect(
+      mintNFT.connect(organizer).resetSecretPhrase(1, newProofCalldata)
+    ).to.be.reverted;
+    await operationController.connect(organizer).unpause();
   });
 });

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -236,6 +236,26 @@ describe("MintNFT", function () {
     });
   });
 
+  describe("burn", () => {
+    it("success to burn", async () => {
+      const { proofCalldata } = await generateProof();
+      const mintNftTxn = await mintNFT
+        .connect(participant2)
+        .mintParticipateNFT(createdGroupId, createdEventIds[0], proofCalldata);
+      await mintNftTxn.wait();
+
+      expect(await mintNFT.balanceOf(participant2.address)).equal(1);
+
+      const tokenId = await mintNFT.tokenOfOwnerByIndex(
+        participant2.address,
+        0
+      );
+
+      await mintNFT.connect(organizer).burn(tokenId);
+      expect(await mintNFT.balanceOf(participant2.address)).equal(0);
+    });
+  });
+
   describe("get NFT holders of the event", () => {
     let mintNFT: MintNFT;
     let eventManager: EventManager;

--- a/hardhat/test/OperationController.ts
+++ b/hardhat/test/OperationController.ts
@@ -1,0 +1,60 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers, upgrades } from "hardhat";
+// eslint-disable-next-line node/no-missing-import
+import { OperationController } from "../typechain";
+import { expect } from "chai";
+
+describe("OperationController", function () {
+  let operationController: OperationController;
+  let organizer: SignerWithAddress;
+  let participant1: SignerWithAddress;
+
+  before(async () => {
+    [organizer, participant1] = await ethers.getSigners();
+    const OperationControllerFactory = await ethers.getContractFactory(
+      "OperationController"
+    );
+    const deployedOperationController: any = await upgrades.deployProxy(
+      OperationControllerFactory,
+      { initializer: "initialize" }
+    );
+    operationController = deployedOperationController;
+    await operationController.deployed();
+  });
+
+  describe("Deployment", function () {
+    it("should set the right owner", async function () {
+      expect(await operationController.owner()).to.equal(organizer.address);
+    });
+
+    it("should set the pause state to false", async function () {
+      expect(await operationController.paused()).to.equal(false);
+    });
+  });
+
+  describe("Pause", function () {
+    it("should revert if not called by owner", async function () {
+      await expect(
+        operationController.connect(participant1).pause()
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("should set the pause state to true", async function () {
+      await operationController.pause();
+      expect(await operationController.paused()).to.equal(true);
+    });
+  });
+
+  describe("Unpause", function () {
+    it("should revert if not called by owner", async function () {
+      await expect(
+        operationController.connect(participant1).unpause()
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("should set the pause state to false", async function () {
+      await operationController.unpause();
+      expect(await operationController.paused()).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
See: https://github.com/hackdays-io/mint-rally/issues/324

- 以下 PR のリトライです。
  - https://github.com/hackdays-io/mint-rally/pull/392

# 対応内容
- 設計
  - https://github.com/hackdays-io/mint-rally/issues/324#issuecomment-1722147222
- OperationController コントラクトの追加
- EventManager コントラクトの修正
  - OperationController を参照して適宜 paused を判定するように修正しました。
- MintNFT コントラクトの修正
  - OperationController を参照して適宜 paused を判定するように修正しました。
- デプロイスクリプトの修正
  - local, stg のスクリプトを修正しました。
  - prod のスクリプトは利用なしと考えて修正していません。
- アップグレードスクリプトの修正
  - v1.2.0 local のスクリプトを修正しました。修正理由はローカルでの検証のためです。

# 確認
## ローカルでのテスト実行
- ローカルにて `npm test` が通る事を確認しました。

## ローカルでのデプロイ
- 修正済みのデプロイスクリプトが動くことを確認しました。

## ローカルでのアップグレード
- 以下手作業でのアップグレードでエラーにならないことを確認しました。
  - hardhat network をローカルで起動
  - staging ブランチの最新コミットでローカルのデプロイを実施
  - OperationController のみのデプロイを実施
  - upgrades/v1.2.0/upgrade_local.ts を実行してアップグレードを実施
```
>> npx hardhat run scripts/upgrades/v1.2.0/upgrade_local.ts --network local
No need to generate any newer typings.
mintNFT address: 0x0165878A594ca255338adfa4d48449f69242Eb8F
eventManager address: 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
```

## コントラクトサイズ
- MintNFT が 24 KB を超えていないことを確認しました。
  - 9/20 burn の対応をなくしたことで少しコードサイズが削減されました。

<details>
<summary>コマンド実行</summary>

```
>> npx hardhat size-contracts
Nothing to compile
No need to generate any newer typings.
 ·-------------------------------|--------------|----------------·
 |  Contract Name                ·  Size (KiB)  ·  Change (KiB)  │
 ································|··············|·················
 |  console                      ·       0.084  ·                │
 ································|··············|·················
 |  Hashing                      ·       0.084  ·                │
 ································|··············|·················
 |  AddressUpgradeable           ·       0.084  ·                │
 ································|··············|·················
 |  StringsUpgradeable           ·       0.084  ·                │
 ································|··············|·················
 |  Counters                     ·       0.084  ·                │
 ································|··············|·················
 |  Strings                      ·       0.084  ·                │
 ································|··············|·················
 |  ECDSAUpgradeable             ·       0.084  ·                │
 ································|··············|·················
 |  ECDSA                        ·       0.084  ·                │
 ································|··············|·················
 |  OperationController          ·       3.041  ·                │
 ································|··············|·················
 |  MinimalForwarderUpgradeable  ·       4.743  ·                │
 ································|··············|·················
 |  MintRallyForwarder           ·       4.934  ·                │
 ································|··············|·················
 |  SecretPhraseVerifier         ·       7.692  ·                │
 ································|··············|·················
 |  ERC721Upgradeable            ·       8.396  ·                │
 ································|··············|·················
 |  EventManager                 ·      14.267  ·                │
 ································|··············|·················
 |  MintNFT                      ·      23.683  ·        -0.173  │
 ·-------------------------------|--------------|----------------·
```

</details>

# 未対応項目
- デプロイ＆アップグレードスクリプト
  - 以下の対応をどう進めるのか判断できず、stg, prod の一部スクリプトが用意できていません。
    - OperationController のみのデプロイ
    - 上記デプロイ後のコントラクトアドレスを使用してのアップグレードスクリプトの用意

# 懸念事項
- MintNFT コントラクトの bytecode サイズ
  - 状況
    - 今回の修正でサイズが 23 KB になりました。
    - 今後、修正を加えようとした際にサイズ上限に引っかかる可能性が上がりました。
  - 要検討
    - 他の修正のためにこの修正のマージは保留する？
    - PR マージのよりもサイズ削減を優先度する？
    - 別途 MintNFT のサイズ削減を対応した後にマージする流れにしても良いかも知れません。
