### PR TITLE
Bugfix: deploy_local script

### DIFF
--- a/hardhat/scripts/deploy_local.ts
+++ b/hardhat/scripts/deploy_local.ts
@@ -27,7 +27,7 @@ async function main() {
   const MintNFTFactory = await ethers.getContractFactory("MintNFT");
   const deployedMintNFT: any = await upgrades.deployProxy(
     MintNFTFactory,
-    [forwarder.address, secretPhraseVerifier.address, []],
+    [forwarder.address, secretPhraseVerifier.address],
     {
       initializer: "initialize",
     }


### PR DESCRIPTION
Close: https://github.com/hackdays-io/mint-rally/issues/406

# 修正
- deploy_local.ts を修正
  - MintNFT の initialize のパラメータを適切な状態に変更しました。

# 確認
- ローカル開発環境にてスクリプトを実行して問題ないことを確認しました。
```
>> yarn deploy:local
yarn run v1.22.17
$ npx hardhat run scripts/deploy_local.ts --network local
No need to generate any newer typings.
forwarder address: 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
secretPhraseVerifier address: 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
mintNFT address: 0x0165878A594ca255338adfa4d48449f69242Eb8F
eventManager address: 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
```
