### PR TITLE
feat: get past event's special urls and required counts

### DIFF
--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -238,7 +238,7 @@ contract MintNFT is
         uint256 _eventId,
         uint256 _limit,
         uint256 _offset
-    ) external view returns (NFTAttribute[] memory) {
+    ) external view onlyGroupOwner(_eventId) returns (NFTAttribute[] memory) {
         if (_limit == 0) {
             _limit == 100; // default limit
         }

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -240,11 +240,14 @@ contract MintNFT is
         uint256 _offset
     ) external view onlyGroupOwner(_eventId) returns (NFTAttribute[] memory) {
         if (_limit == 0) {
-            _limit == 100; // default limit
+            _limit = 100; // default limit
         }
         require(_limit <= 100, "limit is too large");
         // create array of nft attributes
-        NFTAttribute[] memory _nftAttributeRecords = new NFTAttribute[](_limit);
+        NFTAttribute[] memory _nftAttributeRecordsList = new NFTAttribute[](
+            _limit
+        );
+
         uint256 count;
 
         for (uint256 i = _offset; i < _limit; i++) {
@@ -255,9 +258,14 @@ contract MintNFT is
                 keccak256(abi.encodePacked(ipfsUrl)) !=
                 keccak256(abi.encodePacked(""))
             ) {
-                _nftAttributeRecords[count] = NFTAttribute(ipfsUrl, i);
-                ++count;
+                _nftAttributeRecordsList[count] = NFTAttribute(ipfsUrl, i);
+                count++;
             }
+        }
+
+        NFTAttribute[] memory _nftAttributeRecords = new NFTAttribute[](count);
+        for (uint256 j = 0; j < count; j++) {
+            _nftAttributeRecords[j] = _nftAttributeRecordsList[j];
         }
         return _nftAttributeRecords;
     }

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -248,6 +248,11 @@ contract MintNFT is
             _limit
         );
 
+        require(
+            _offset <= type(uint256).max - _limit,
+            "limit + offset must be <= 2^256 - 1"
+        );
+
         uint256 limitWithOffset = _limit + _offset;
         uint256 count;
 

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -234,6 +234,34 @@ contract MintNFT is
         return remainingEventNftCount[_eventId];
     }
 
+    function getNFTAttributeRecordsByEventId(
+        uint256 _eventId,
+        uint256 _limit,
+        uint256 _offset
+    ) external view returns (NFTAttribute[] memory) {
+        if (_limit == 0) {
+            _limit == 100; // default limit
+        }
+        require(_limit <= 100, "limit is too large");
+        // create array of nft attributes
+        NFTAttribute[] memory _nftAttributeRecords = new NFTAttribute[](_limit);
+        uint256 count;
+
+        for (uint256 i = _offset; i < _limit; i++) {
+            string memory ipfsUrl = eventNftAttributes[
+                Hashing.hashingDoubleUint256(_eventId, i)
+            ];
+            if (
+                keccak256(abi.encodePacked(ipfsUrl)) !=
+                keccak256(abi.encodePacked(""))
+            ) {
+                _nftAttributeRecords[count] = NFTAttribute(ipfsUrl, i);
+                ++count;
+            }
+        }
+        return _nftAttributeRecords;
+    }
+
     function burn(uint256 tokenId) public onlyOwner {
         _burn(tokenId);
     }

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -248,9 +248,10 @@ contract MintNFT is
             _limit
         );
 
+        uint256 limitWithOffset = _limit + _offset;
         uint256 count;
 
-        for (uint256 i = _offset; i < _limit; i++) {
+        for (uint256 i = _offset; i < limitWithOffset; i++) {
             string memory ipfsUrl = eventNftAttributes[
                 Hashing.hashingDoubleUint256(_eventId, i)
             ];

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -348,41 +348,6 @@ describe("MintNFT", function () {
   });
 
   describe("getNFTAttributeRecordsByEventId", () => {
-    let mintNFT: MintNFT;
-    let eventManager: EventManager;
-
-    let createdGroupId1: number;
-
-    let organizer: SignerWithAddress;
-    let participant1: SignerWithAddress;
-    let relayer: SignerWithAddress;
-
-    before(async () => {
-      [organizer, participant1, relayer] = await ethers.getSigners();
-
-      // generate proof
-      const { publicInputCalldata } = await generateProof();
-
-      // Deploy all contracts
-      [, mintNFT, eventManager] = await deployAll(relayer);
-
-      // Create a Group and an Event
-      await createGroup(eventManager, "First Group");
-      const groupsList = await eventManager.getGroups();
-      createdGroupId1 = groupsList[0].groupId.toNumber();
-
-      await createEventRecord(eventManager, {
-        groupId: createdGroupId1,
-        name: "event1",
-        description: "event1 description",
-        date: "2022-07-3O",
-        mintLimit: 10,
-        useMtx: false,
-        secretPhrase: publicInputCalldata[0],
-        eventNFTAttributes: attributes,
-      });
-    });
-
     it("should revert if msg.sender is not group owner", async () => {
       await expect(
         mintNFT.connect(participant1).getNFTAttributeRecordsByEventId(1, 100, 0)

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -360,6 +360,14 @@ describe("MintNFT", function () {
       ).to.be.revertedWith("limit is too large");
     });
 
+    it("should revert if limit + offset is over flow", async () => {
+      await expect(
+        mintNFT
+          .connect(organizer)
+          .getNFTAttributeRecordsByEventId(1, 100, ethers.constants.MaxUint256)
+      ).to.be.revertedWith("limit + offset must be <= 2^256 - 1");
+    });
+
     it("get NFTAttributeRecords by event id", async () => {
       const nftAttributeRecords = await mintNFT
         .connect(organizer)

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -345,6 +345,31 @@ describe("MintNFT", function () {
         expect(Number(nftholders[3].eventId)).equal(1);
       });
     });
+
+    describe("getNFTAttributeRecordsByEventId", () => {
+      it("get NFTAttributeRecords by event id", async () => {
+        const nftAttributeRecords =
+          await mintNFT.getNFTAttributeRecordsByEventId(
+            createdEventIds[0],
+            0,
+            100
+          );
+        console.log(nftAttributeRecords);
+        // expect(nftAttributeRecords.length).equal(3);
+        // expect(nftAttributeRecords[0].metaDataURL).equal(
+        //   "ipfs://hogehoge/count0.json"
+        // );
+        // expect(nftAttributeRecords[1].metaDataURL).equal(
+        //   "ipfs://hogehoge/count1.json"
+        // );
+        // expect(nftAttributeRecords[2].metaDataURL).equal(
+        //   "ipfs://hogehoge/count5.json"
+        // );
+        // expect(nftAttributeRecords[0].requiredParticipateCount).equal(0);
+        // expect(nftAttributeRecords[1].requiredParticipateCount).equal(1);
+        // expect(nftAttributeRecords[2].requiredParticipateCount).equal(5);
+      });
+    });
   });
 
   // it("reject mint NFT when secret phrase is invalid", async () => {
@@ -593,3 +618,5 @@ describe("reset secret phrase", () => {
     ).to.be.revertedWith("you are not event group owner");
   });
 });
+
+describe("setEventInfo", () => {});


### PR DESCRIPTION
作業中になります！
ガスオプティマイザー実装後に再開予定です。

過去の該当イベントIDのスペシャルNFTの画像と必要参加回数を取得する関数を実装。

close #410 