### PR TITLE
Feature/386 footer link to x

### DIFF
--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -36,6 +36,22 @@ const Footer = () => (
           Discord
         </Box>
       </Link>
+      <Link href="https://twitter.com/mint_rally" target="_blank">
+        <Box
+          cursor="pointer"
+          as="span"
+          py="1"
+          px="3"
+          ml={2}
+          backgroundColor="mint.bg"
+          borderRadius="full"
+          fontSize="sm"
+          color="mint.primary"
+          fontWeight="bold"
+        >
+          X
+        </Box>
+      </Link>
     </Box>
   </Box>
 );


### PR DESCRIPTION
See: https://github.com/hackdays-io/mint-rally/issues/386

# 対応内容
- フッターに MintRally オフィシャルアカウントへのリンクを追加
  - Footer コンポーネントに追加したためコンポーネントを使用している箇所全体に影響

# 確認
- ローカルの開発サーバにて確認

![image](https://github.com/hackdays-io/mint-rally/assets/1365859/5c7b7c50-693c-4baa-8450-132a2b06b44f)

# 気になった点
- GitHub, Discrod のリンクに `target="_blank"` が実装されているものの動いていなさそうな点
