### PR TITLE
Feature/320 role base access

### DIFF
--- a/hardhat/contracts/Event.sol
+++ b/hardhat/contracts/Event.sol
@@ -284,32 +284,22 @@ contract EventManager is OwnableUpgradeable {
         return isGroupOwner;
     }
 
-    function grantAdminRole(uint256 _groupId, address _address) external {
-        _grantRole(_groupId, _address, ADMIN_ROLE);
-    }
-
-    function grantCollaboratorRole(uint256 _groupId, address _address) external {
-        _grantRole(_groupId, _address, COLLABORATOR_ROLE);
-    }
-
-    function revokeAdminRole(uint256 _groupId, address _address) external {
-        _revokeRole(_groupId, _address, ADMIN_ROLE);
-    }
-
-    function revokeCollaboratorRole(uint256 _groupId, address _address) external {
-        _revokeRole(_groupId, _address, COLLABORATOR_ROLE);
-    }
-
-    function _grantRole(uint256 _groupId, address _address, bytes32 _role) private whenNotPaused {
+    function grantRole(uint256 _groupId, address _address, bytes32 _role) external whenNotPaused {
         require(_isGroupOwnerOrAdmin(_groupId, msg.sender), "Not permitted");
+        require(_isValidRole(_role), "Invalid role");
 
         memberRolesByGroupId[_groupId][_address][_role] = true;
     }
 
-    function _revokeRole(uint256 _groupId, address _address, bytes32 _role) private whenNotPaused {
+    function revokeRole(uint256 _groupId, address _address, bytes32 _role) external whenNotPaused {
         require(_isGroupOwnerOrAdmin(_groupId, msg.sender), "Not permitted");
+        require(_isValidRole(_role), "Invalid role");
 
         delete memberRolesByGroupId[_groupId][_address][_role];
+    }
+
+    function _isValidRole(bytes32 _role) private pure returns (bool) {
+        return _role == ADMIN_ROLE || _role == COLLABORATOR_ROLE;
     }
 
     function _isGroupOwnerOrAdmin(uint256 _groupId, address _sender) private view returns (bool) {


### PR DESCRIPTION
See: https://github.com/hackdays-io/mint-rally/issues/320

# 対応の分割
- この PR ではロールのデータ保持に関する部分までの実装にしています。
  - PR をできるだけ小さくしてレビューしやすくするため。
- そのためロールベースの API アクセス制御側は未実装です。
  - 残りの実装はこの PR のブランチより生やしておこなう予定です。


# 対応内容
- ロール保持用の状態変数の追加
  - admin, collaborator ロールの const も追加
- grantRole API の追加
  - ロール付与時に使用されることを想定
  - グループオーナーもしくは Admin ロール保持者のみ利用可能
- revokeRole API の追加
  - ロール剥奪時に使用されることを想定
  - グループオーナーもしくは Admin ロール保持者のみ利用可能
- ~~isXxx API の追加~~（10/10 設計変更のため削除）
  - ~~sender 自身がロールを保持しているか判定するために使用されることを想定~~
- アドレスのロール付与状況を取得する API の追加（10/10 設計変更で追加）
  - ロールの付与状況を判定するために使用されることを想定


# レビューの観点
- API の設計に違和感がないかどうか
- Solidity の実装としておかしな点がないかどうか
- 変数名、関数名におかしい点がないかどうか
- validation や機能面で実装漏れなどないかどうか
- テストのヌケモレなどないか


# 確認
- ローカル環境にてテストを実行して確認

```
>> git br -v -a
* feature/320-role-base-access                        d0bef04 fix grantRole and revokeRole
  staging                                             72d6f09 Merge pull request #439 from hackdays-io/feature/secretPhraseQueryParam

>> yarn test
yarn run v1.22.19
$ npx hardhat compile && npx hardhat test
...
  60 passing (2m)

✨  Done in 113.89s.
```


# コントラクトサイズ
```
|  EventManager                 ·      10.487  ·        +1.379  │
```

# メモ
- ロール保持者の一覧取得用 API は今後必要になるのかも？
  - フロントエンドでの表示機能や権限剥奪機能を作る際に必要そう。
- バルク処理用の一括登録 API も将来的には必要になるのかも？
  - 複数アドレスを追加するケースがあった場合にあったら便利かも。
