### PR TITLE
Feature/320 role base access 2

### DIFF
--- a/hardhat/contracts/Event.sol
+++ b/hardhat/contracts/Event.sol
@@ -267,21 +267,6 @@ contract EventManager is OwnableUpgradeable {
         return _eventRecord;
     }
 
-    // TODO: Remove after isGroupOwnerOrAdminOrCollaboratorByEventId is released
-    function isGroupOwnerByEventId(
-        address _address,
-        uint256 _eventId
-    ) public view returns (bool) {
-        uint256 _groupId = groupIdByEventId[_eventId];
-        bool isGroupOwner = false;
-        for (uint256 _i = 0; _i < ownGroupIds[_address].length; _i++) {
-            if (ownGroupIds[_address][_i] == _groupId) {
-                isGroupOwner = true;
-            }
-        }
-        return isGroupOwner;
-    }
-
     function isGroupOwnerOrAdminOrCollaboratorByEventId(address _address, uint256 _eventId) external view returns (bool) {
         uint256 _groupId = groupIdByEventId[_eventId];
         return _isGroupOwnerOrAdminOrCollaborator(_groupId, _address);

--- a/hardhat/contracts/Event.sol
+++ b/hardhat/contracts/Event.sol
@@ -58,14 +58,11 @@ contract EventManager is OwnableUpgradeable {
     // groupId => address => Role => bool
     mapping(uint256 => mapping(address => mapping(bytes32 => bool))) private memberRolesByGroupId;
 
-    modifier onlyGroupOwner(uint256 _groupId) {
-        bool _isGroupOwner = false;
-        for (uint256 _i = 0; _i < ownGroupIds[msg.sender].length; _i++) {
-            if (ownGroupIds[msg.sender][_i] == _groupId) {
-                _isGroupOwner = true;
-            }
-        }
-        require(_isGroupOwner, "You are not group owner");
+    modifier onlyGroupOwnerOrAdminOrCollaborator(uint256 _groupId) {
+        require(
+            _isGroupOwnerOrAdmin(_groupId, msg.sender) || _hasRole(_groupId, msg.sender, COLLABORATOR_ROLE),
+            "You have no permission"
+        );
         _;
     }
 
@@ -172,7 +169,7 @@ contract EventManager is OwnableUpgradeable {
         bool _useMtx,
         bytes32 _secretPhrase,
         IMintNFT.NFTAttribute[] memory _eventNFTAttributes
-    ) external payable onlyGroupOwner(_groupId) whenNotPaused {
+    ) external payable onlyGroupOwnerOrAdminOrCollaborator(_groupId) whenNotPaused {
         require(
             _mintLimit > 0 && _mintLimit <= maxMintLimit,
             "mint limit is invalid"

--- a/hardhat/contracts/IEvent.sol
+++ b/hardhat/contracts/IEvent.sol
@@ -10,12 +10,6 @@ struct EventRecord {
 }
 
 interface IEventManager {
-    // TODO: Remove after isGroupOwnerOrAdminOrCollaboratorByEventId is released
-    function isGroupOwnerByEventId(
-        address _addr,
-        uint256 _eventId
-    ) external view returns (bool);
-
     function isGroupOwnerOrAdminOrCollaboratorByEventId(
         address _addr,
         uint256 _eventId

--- a/hardhat/contracts/IEvent.sol
+++ b/hardhat/contracts/IEvent.sol
@@ -10,7 +10,13 @@ struct EventRecord {
 }
 
 interface IEventManager {
+    // TODO: Remove after isGroupOwnerOrAdminOrCollaboratorByEventId is released
     function isGroupOwnerByEventId(
+        address _addr,
+        uint256 _eventId
+    ) external view returns (bool);
+
+    function isGroupOwnerOrAdminOrCollaboratorByEventId(
         address _addr,
         uint256 _eventId
     ) external view returns (bool);

--- a/hardhat/contracts/IEvent.sol
+++ b/hardhat/contracts/IEvent.sol
@@ -10,7 +10,7 @@ struct EventRecord {
 }
 
 interface IEventManager {
-    function isGroupOwnerOrAdminOrCollaboratorByEventId(
+    function hasCollaboratorAccessByEventId(
         address _addr,
         uint256 _eventId
     ) external view returns (bool);

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -64,10 +64,10 @@ contract MintNFT is
     event MintLocked(uint256 indexed eventId, bool isLocked);
     event ResetSecretPhrase(address indexed executor, uint256 indexed eventId);
 
-    modifier onlyGroupOwnerOrAdminOrCollaborator(uint256 _eventId) {
+    modifier onlyCollaboratorAccess(uint256 _eventId) {
         IEventManager eventManager = IEventManager(eventManagerAddr);
         require(
-            eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(msg.sender, _eventId),
+            eventManager.hasCollaboratorAccessByEventId(msg.sender, _eventId),
             "you have no permission"
         );
         _;
@@ -194,7 +194,7 @@ contract MintNFT is
     function changeMintLocked(
         uint256 _eventId,
         bool _locked
-    ) external onlyGroupOwnerOrAdminOrCollaborator(_eventId) whenNotPaused {
+    ) external onlyCollaboratorAccess(_eventId) whenNotPaused {
         isMintLocked[_eventId] = _locked;
         emit MintLocked(_eventId, _locked);
     }
@@ -202,7 +202,7 @@ contract MintNFT is
     function resetSecretPhrase(
         uint256 _eventId,
         bytes32 _secretPhrase
-    ) external onlyGroupOwnerOrAdminOrCollaborator(_eventId) whenNotPaused {
+    ) external onlyCollaboratorAccess(_eventId) whenNotPaused {
         eventSecretPhrases[_eventId] = _secretPhrase;
         emit ResetSecretPhrase(_msgSender(), _eventId);
     }

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -64,11 +64,11 @@ contract MintNFT is
     event MintLocked(uint256 indexed eventId, bool isLocked);
     event ResetSecretPhrase(address indexed executor, uint256 indexed eventId);
 
-    modifier onlyGroupOwner(uint256 _eventId) {
+    modifier onlyGroupOwnerOrAdminOrCollaborator(uint256 _eventId) {
         IEventManager eventManager = IEventManager(eventManagerAddr);
         require(
-            eventManager.isGroupOwnerByEventId(msg.sender, _eventId),
-            "you are not event group owner"
+            eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(msg.sender, _eventId),
+            "you have no permission"
         );
         _;
     }
@@ -194,7 +194,7 @@ contract MintNFT is
     function changeMintLocked(
         uint256 _eventId,
         bool _locked
-    ) external onlyGroupOwner(_eventId) whenNotPaused {
+    ) external onlyGroupOwnerOrAdminOrCollaborator(_eventId) whenNotPaused {
         isMintLocked[_eventId] = _locked;
         emit MintLocked(_eventId, _locked);
     }
@@ -202,7 +202,7 @@ contract MintNFT is
     function resetSecretPhrase(
         uint256 _eventId,
         bytes32 _secretPhrase
-    ) external onlyGroupOwner(_eventId) whenNotPaused {
+    ) external onlyGroupOwnerOrAdminOrCollaborator(_eventId) whenNotPaused {
         eventSecretPhrases[_eventId] = _secretPhrase;
         emit ResetSecretPhrase(_msgSender(), _eventId);
     }

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -67,7 +67,7 @@ contract MintNFT is
     modifier onlyCollaboratorAccess(uint256 _eventId) {
         IEventManager eventManager = IEventManager(eventManagerAddr);
         require(
-            eventManager.hasCollaboratorAccessByEventId(msg.sender, _eventId),
+            eventManager.hasCollaboratorAccessByEventId(_msgSender(), _eventId),
             "you have no permission"
         );
         _;

--- a/hardhat/test/EventManager.ts
+++ b/hardhat/test/EventManager.ts
@@ -1057,7 +1057,7 @@ describe("EventManager", function () {
       });
     });
 
-    describe("isGroupOwnerOrAdminOrCollaboratorByEventId", async () => {
+    describe("hasCollaboratorAccessByEventId", async () => {
       let publicInputCalldata: any;
 
       beforeEach(async () => {
@@ -1108,7 +1108,7 @@ describe("EventManager", function () {
         const eventId = eventRecords[1].eventRecordId.toNumber(); // 2nd event id
 
         expect(
-          await eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(
+          await eventManager.hasCollaboratorAccessByEventId(
             organizer.address,
             eventId
           )
@@ -1116,13 +1116,13 @@ describe("EventManager", function () {
 
         // check before grant
         expect(
-          await eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(
+          await eventManager.hasCollaboratorAccessByEventId(
             participant1.address,
             eventId
           )
         ).to.equal(false);
         expect(
-          await eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(
+          await eventManager.hasCollaboratorAccessByEventId(
             participant2.address,
             eventId
           )
@@ -1136,13 +1136,13 @@ describe("EventManager", function () {
           COLLABORATOR_ROLE
         );
         expect(
-          await eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(
+          await eventManager.hasCollaboratorAccessByEventId(
             participant1.address,
             eventId
           )
         ).to.equal(true);
         expect(
-          await eventManager.isGroupOwnerOrAdminOrCollaboratorByEventId(
+          await eventManager.hasCollaboratorAccessByEventId(
             participant2.address,
             eventId
           )

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -600,7 +600,39 @@ describe("mint locked flag", () => {
   it("No one but the owner should be able to change mintable flag", async () => {
     await expect(
       mintNFT.connect(participant1).changeMintLocked(1, false)
-    ).to.be.revertedWith("you are not event group owner");
+    ).to.be.revertedWith("you have no permission");
+  });
+
+  it("should change flag by admin", async () => {
+    await expect(
+      mintNFT.connect(participant1).changeMintLocked(1, false)
+    ).to.be.revertedWith("you have no permission");
+
+    eventManager
+      .connect(organizer)
+      .grantAdminRole(createdGroupId, participant1.address);
+    await mintNFT.connect(participant1).changeMintLocked(1, false);
+
+    // Clean up
+    eventManager
+      .connect(organizer)
+      .revokeAdminRole(createdGroupId, participant1.address);
+  });
+
+  it("should change flag by collaborator", async () => {
+    await expect(
+      mintNFT.connect(participant1).changeMintLocked(1, false)
+    ).to.be.revertedWith("you have no permission");
+
+    eventManager
+      .connect(organizer)
+      .grantCollaboratorRole(createdGroupId, participant1.address);
+    await mintNFT.connect(participant1).changeMintLocked(1, false);
+
+    // Clean up
+    eventManager
+      .connect(organizer)
+      .revokeCollaboratorRole(createdGroupId, participant1.address);
   });
 
   it("should not change if paused", async () => {
@@ -668,7 +700,45 @@ describe("reset secret phrase", () => {
       "0x1f376ca3150d51a164c711287cff6e77e2127d635a1534b41d5624472f000000";
     await expect(
       mintNFT.connect(participant1).resetSecretPhrase(1, newProofCalldata)
-    ).to.be.revertedWith("you are not event group owner");
+    ).to.be.revertedWith("you have no permission");
+  });
+
+  it("should reset secret phrase by admin", async () => {
+    const newProofCalldata =
+      "0x1f376ca3150d51a164c711287cff6e77e2127d635a1534b41d5624472f000000";
+
+    await expect(
+      mintNFT.connect(participant1).resetSecretPhrase(1, newProofCalldata)
+    ).to.be.revertedWith("you have no permission");
+
+    eventManager
+      .connect(organizer)
+      .grantAdminRole(createdGroupId, participant1.address);
+    await mintNFT.connect(participant1).resetSecretPhrase(1, newProofCalldata);
+
+    // Clean up
+    eventManager
+      .connect(organizer)
+      .revokeAdminRole(createdGroupId, participant1.address);
+  });
+
+  it("should reset secret phrase by collaborator", async () => {
+    const newProofCalldata =
+      "0x1f376ca3150d51a164c711287cff6e77e2127d635a1534b41d5624472f000000";
+
+    await expect(
+      mintNFT.connect(participant1).resetSecretPhrase(1, newProofCalldata)
+    ).to.be.revertedWith("you have no permission");
+
+    eventManager
+      .connect(organizer)
+      .grantCollaboratorRole(createdGroupId, participant1.address);
+    await mintNFT.connect(participant1).resetSecretPhrase(1, newProofCalldata);
+
+    // Clean up
+    eventManager
+      .connect(organizer)
+      .revokeCollaboratorRole(createdGroupId, participant1.address);
   });
 
   it("cannot change if paused", async () => {


### PR DESCRIPTION
See: https://github.com/hackdays-io/mint-rally/issues/320

# 第二弾の PR
- この PR は以下第一弾 PR の続きです。
  - https://github.com/hackdays-io/mint-rally/pull/441
- fork したリポジトリから PR を作成しているため第一弾に含まれるコミットも含んだ内容になっています。
- そのためレビューはコミット単位に見て頂いた方が見やすいかと思います。

# 対応内容
- EventManager の API に RBAC を追加
  - https://github.com/hackdays-io/mint-rally/commit/6742087bb744dca5105421520df41426a8080b57
  - admin & collaborator でもイベント作成を可能とするように修正。
- MintNFT の API に RBAC を追加
  - https://github.com/hackdays-io/mint-rally/commit/8c33cc1fe38c2730dded3574f026bc50469196d8
  - admin & collaborator でもイベントのロックとあいことばの変更を可能とするように修正。
- `isGroupOwnerByEventId` は使用しなくなったため削除
  - https://github.com/hackdays-io/mint-rally/commit/062a22e37bce6bdf94fbc84f93444c217afa0f83
- hasCollboratorAccess へと諸々の関数名をリネーム
  - https://github.com/hackdays-io/mint-rally/pull/444/commits/eb5e6a77cbc1fc6b3c744f415eb46ce14e2d182c


# レビューの観点
- Solidity の実装としておかしな点がないかどうか
- 変数名、関数名におかしい点がないかどうか
- 機能面で実装漏れなどないかどうか
- テストのヌケモレなどないか


# 確認
- ローカル環境にてテストを実行して確認

```
>> git br -v -a
  feature/320-role-base-access                        d0bef04 fix grantRole and revokeRole
* feature/320-role-base-access-2                      eb5e6a7 rename to hasCollaboratorAccess
  staging                                             72d6f09 Merge pull request #439 from hackdays-io/feature/secretPhraseQueryParam

>> yarn test
yarn run v1.22.19
$ npx hardhat compile && npx hardhat test
...
  68 passing (2m)

✨  Done in 118.31s.
```


# コントラクトサイズ
- 第一弾 PR のブランチからの差分です。

```
 |  EventManager                 ·      10.446  ·        -0.041  │
 ································|··············|·················
 |  MintNFT                      ·      13.518  ·        -0.014  │
```


# 設計：ロールとオーナーによるアクセスコントロール
- アクセスコントロールにおける 3 つの役割
  - Collaboralr
  - Admin
  - Group Owner
- 各役割のは以下の関係とする
  - Collaboralr <= Admin <= Group Owner
  - 下位のものが最も権限は小さく、上位のものは下位の権限を有するものとする

## アクセス権限の判定と内容
- `hasCollaboratorAccess()`
  - Collaboralr & Admin & Group Owner によるアクセスを許可する
  - 利用可能な機能
    - イベントの作成
    - イベントの Lock & Unlock 
    - あいことばの変更
- `hasAdminAccess()`
  - Admin & Group Owner によるアクセスを許可する
  - 利用可能な機能
    - Admin & Collaborator の追加削除
- `hasOwnerAccess()` 
  - Group Owner のみのアクセスを許可する
  - 利用可能な機能
    - グループオーナーの変更
