### PR TITLE
Feature/320 rbac event emit

### DIFF
--- a/hardhat/contracts/Event.sol
+++ b/hardhat/contracts/Event.sol
@@ -105,6 +105,8 @@ contract EventManager is OwnableUpgradeable {
 
     event CreateGroup(address indexed owner, uint256 groupId);
     event CreateEvent(address indexed owner, uint256 eventId);
+    event GrantRole(uint256 indexed groupId, address member, bytes32 role);
+    event RevokeRole(uint256 indexed groupId, address member, bytes32 role);
 
     // Currently, reinitializer(2) was executed as constructor.
     function initialize(
@@ -277,6 +279,8 @@ contract EventManager is OwnableUpgradeable {
         require(_isValidRole(_role), "Invalid role");
 
         memberRolesByGroupId[_groupId][_address][_role] = true;
+
+        emit GrantRole(_groupId, _address, _role);
     }
 
     function revokeRole(uint256 _groupId, address _address, bytes32 _role) external whenNotPaused {
@@ -284,6 +288,8 @@ contract EventManager is OwnableUpgradeable {
         require(_isValidRole(_role), "Invalid role");
 
         delete memberRolesByGroupId[_groupId][_address][_role];
+
+        emit RevokeRole(_groupId, _address, _role);
     }
 
     function _isValidRole(bytes32 _role) private pure returns (bool) {

--- a/hardhat/contracts/Event.sol
+++ b/hardhat/contracts/Event.sol
@@ -105,8 +105,8 @@ contract EventManager is OwnableUpgradeable {
 
     event CreateGroup(address indexed owner, uint256 groupId);
     event CreateEvent(address indexed owner, uint256 eventId);
-    event GrantRole(uint256 indexed groupId, address member, bytes32 role);
-    event RevokeRole(uint256 indexed groupId, address member, bytes32 role);
+    event GrantRole(uint256 indexed groupId, address addr, bytes32 role);
+    event RevokeRole(uint256 indexed groupId, address addr, bytes32 role);
 
     // Currently, reinitializer(2) was executed as constructor.
     function initialize(

--- a/hardhat/test/EventManager.ts
+++ b/hardhat/test/EventManager.ts
@@ -647,9 +647,11 @@ describe("EventManager", function () {
           admin: false,
           collaborator: false,
         });
-        await eventManager
-          .connect(organizer)
-          .grantRole(groupId, organizer.address, ADMIN_ROLE);
+        await expect(
+          eventManager
+            .connect(organizer)
+            .grantRole(groupId, organizer.address, ADMIN_ROLE)
+        ).to.emit(eventManager, "GrantRole");
         expectRoles(groupId, organizer.address, {
           admin: true,
           collaborator: false,
@@ -838,9 +840,11 @@ describe("EventManager", function () {
           admin: true,
           collaborator: true,
         });
-        await eventManager
-          .connect(organizer)
-          .revokeRole(groupId, organizer.address, ADMIN_ROLE);
+        await expect(
+          eventManager
+            .connect(organizer)
+            .revokeRole(groupId, organizer.address, ADMIN_ROLE)
+        ).to.emit(eventManager, "RevokeRole");
         expectRoles(groupId, organizer.address, {
           admin: false,
           collaborator: true,


### PR DESCRIPTION
See: https://github.com/hackdays-io/mint-rally/issues/320

# 対応内容
- grantRole, revokeRole の Event を追加
  - フロントエンドでトランザクションの成功を判定する際にイベントの受信を使用するために追加します。

# レビューの観点
- Solidity の実装としておかしな点がないかどうか
- イベント名におかしい点がないかどうか

# 確認
- ローカル環境にてテストを実行して確認

# コントラクトサイズ
```
|  EventManager                 ·      10.560  ·        +0.113  │
```
