### PR TITLE
Burn by user

### DIFF
--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -286,8 +286,15 @@ contract MintNFT is
         return _nftAttributeRecords;
     }
 
-    function burn(uint256 tokenId) public onlyOwner {
-        _burn(tokenId);
+    // 既存の burn 関数の名前を変更
+    function burnByOwner(uint256 tokenId) public onlyOwner {
+    _burn(tokenId);
+    }
+    
+    // ユーザーが自身のNFTをバーンできるようにする新しい burn 関数
+    function burn(uint256 tokenId) public {
+    require(_isApprovedOrOwner(_msgSender(), tokenId), "caller is not owner nor approved");
+    _burn(tokenId);
     }
 
     function tokenURI(

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -251,6 +251,10 @@ describe("MintNFT", function () {
         0
       );
 
+      // participant2がorganizerにトークンの操作を承認
+      await mintNFT.connect(participant2).approve(organizer.address, tokenId);
+
+      // 承認後にburnを実行
       await mintNFT.connect(organizer).burn(tokenId);
       expect(await mintNFT.balanceOf(participant2.address)).equal(0);
     });


### PR DESCRIPTION
・ユーザーが自身の所有するNFTをバーン出来るようにする
・owner のみが実行できる既にある burn() を別の名前に変更