### PR TITLE
Implement Terms of Use Agreement - Closes #482

### DIFF
--- a/frontend/src/components/atoms/web3/AgreementModal.tsx
+++ b/frontend/src/components/atoms/web3/AgreementModal.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@chakra-ui/react";
+import { FC } from "react";
+import { useLocale } from "../../../hooks/useLocale";
+
+type Props = {
+  agreementText: string;
+  };
+
+const AgreementModal: FC<Props> = ({
+  agreementText,
+}) => {
+
+  const { t } = useLocale();
+
+  return (
+    <Text color="gray.700" fontSize="sm">
+    {agreementText}
+    </Text>
+  )
+}
+
+export default AgreementModal;

--- a/frontend/src/components/atoms/web3/LoginRequired.tsx
+++ b/frontend/src/components/atoms/web3/LoginRequired.tsx
@@ -9,12 +9,14 @@ type Props = {
   children: ReactNode;
   requiredChainID?: number;
   forbiddenText: string;
+  agreementText: string;
 };
 
 const LoginRequired: FC<Props> = ({
   children,
   requiredChainID = Number(process.env.NEXT_PUBLIC_CHAIN_ID!),
   forbiddenText,
+  agreementText,
 }) => {
   const address = useAddress();
   const chainId = useChainId()!;
@@ -46,6 +48,11 @@ const LoginRequired: FC<Props> = ({
             />
           </HStack>
           <SelectConnectWallet setConnecting={setConnecting} />
+          <Box p={4}>
+           <Text color="gray.700" fontSize="md">
+             {agreementText}
+           </Text>
+         </Box>
         </Box>
       ) : chainId !== requiredChainID ? (
         <Box

--- a/frontend/src/components/atoms/web3/WelcomeModal.tsx
+++ b/frontend/src/components/atoms/web3/WelcomeModal.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@chakra-ui/react";
+import { FC } from "react";
+import { useLocale } from "../../../hooks/useLocale";
+
+type Props = {
+  welcomeText: string;
+  };
+
+const WelcomeModal: FC<Props> = ({
+  welcomeText,
+}) => {
+
+  const { t } = useLocale();
+
+  return (
+    <Text color="gray.700" fontSize="xl">
+    {welcomeText}
+    </Text>
+  )
+}
+
+export default WelcomeModal;

--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -52,6 +52,54 @@ const Footer = () => (
           X
         </Box>
       </Link>
+      <Link href="https://hackdays.notion.site/86dea1026e4943c180f806027d200815?pvs=4" target="_blank">
+        <Box
+          cursor="pointer"
+          as="span"
+          py="1"
+          px="3"
+          ml={2}
+          backgroundColor="mint.bg"
+          borderRadius="full"
+          fontSize="sm"
+          color="mint.primary"
+          fontWeight="bold"
+        >
+          Terms
+        </Box>
+      </Link>
+      <Link href="https://hackdays.notion.site/d13993b3865344d6b6d754821b057a10?pvs=4" target="_blank">
+        <Box
+          cursor="pointer"
+          as="span"
+          py="1"
+          px="3"
+          ml={2}
+          backgroundColor="mint.bg"
+          borderRadius="full"
+          fontSize="sm"
+          color="mint.primary"
+          fontWeight="bold"
+        >
+          Privacy
+        </Box>
+      </Link>
+      <Link href="https://hackdays.notion.site/1bccde1919f04d78a5b0d5b148c65f11?pvs=4" target="_blank">
+        <Box
+          cursor="pointer"
+          as="span"
+          py="1"
+          px="3"
+          ml={2}
+          backgroundColor="mint.bg"
+          borderRadius="full"
+          fontSize="sm"
+          color="mint.primary"
+          fontWeight="bold"
+        >
+          SCTA
+        </Box>
+      </Link>
     </Box>
   </Box>
 );

--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 
 const Footer = () => (
   <Box padding={3} textAlign="center" color="mint.front">
-    <Text>© 2023 Hackdays project</Text>
     <Box mt={2}>
       <Link href="https://github.com/hackdays-io/mint-rally" target="_blank">
         <Box
@@ -52,6 +51,7 @@ const Footer = () => (
           X
         </Box>
       </Link>
+      <Text>© 2023 Hackdays project</Text>
       <Link href="https://hackdays.notion.site/86dea1026e4943c180f806027d200815?pvs=4" target="_blank">
         <Box
           cursor="pointer"
@@ -59,7 +59,7 @@ const Footer = () => (
           py="1"
           px="3"
           ml={2}
-          backgroundColor="mint.bg"
+          //backgroundColor="mint.bg"
           borderRadius="full"
           fontSize="sm"
           color="mint.primary"
@@ -75,7 +75,7 @@ const Footer = () => (
           py="1"
           px="3"
           ml={2}
-          backgroundColor="mint.bg"
+          //backgroundColor="mint.bg"
           borderRadius="full"
           fontSize="sm"
           color="mint.primary"
@@ -91,7 +91,7 @@ const Footer = () => (
           py="1"
           px="3"
           ml={2}
-          backgroundColor="mint.bg"
+          //backgroundColor="mint.bg"
           borderRadius="full"
           fontSize="sm"
           color="mint.primary"

--- a/frontend/src/components/molecules/web3/ConnectWalletModal.tsx
+++ b/frontend/src/components/molecules/web3/ConnectWalletModal.tsx
@@ -24,9 +24,11 @@ export const ConnectWalletModal: FC<Props> = ({
 
   return (
     <>
-      <ModalBase maxWidth="500px" onClose={onClose} isOpen={isOpen}>
+      <ModalBase maxWidth="600px" onClose={onClose} isOpen={isOpen}>
         <Box mt={8} mb={4}>
           <Text mb={4} textAlign="center" fontWeight="bold" fontSize="xl">
+            Welcome to MintRally!
+            <br/>
             MintRally へようこそ
           </Text>
           <Grid gap={2} justifyContent="center">
@@ -55,6 +57,14 @@ export const ConnectWalletModal: FC<Props> = ({
             )}
           </Grid>
         </Box>
+          <Box p={4} mb={0}>
+            <Text mb={4} textAlign="center" fontWeight="normal" fontSize="sm">
+              Please connect your wallet to this website only if you agree to the Terms of Use and Privacy Policy.
+              <br/>
+              <br/>
+              利用規約、プライバシーポリシーにご同意いただいた場合のみ本ウェブサイトにウォレットを接続してください。
+            </Text>
+          </Box>
       </ModalBase>
     </>
   );

--- a/frontend/src/components/molecules/web3/ConnectWalletModal.tsx
+++ b/frontend/src/components/molecules/web3/ConnectWalletModal.tsx
@@ -5,6 +5,9 @@ import MetamaskConnectButton from "src/components/atoms/web3/MetamaskConnectButt
 import SafeConnectButton from "src/components/atoms/web3/SafeConnectButton";
 import WalletConnectButton from "src/components/atoms/web3/WalletConnectButton";
 import ModalBase from "../common/ModalBase";
+import { useLocale } from "../../../hooks/useLocale";
+import WelcomeModal from "src/components/atoms/web3/WelcomeModal";
+import AgreementModal from "src/components/atoms/web3/AgreementModal";
 
 type Props = {
   setConnecting: (connecting: boolean) => void;
@@ -17,6 +20,7 @@ export const ConnectWalletModal: FC<Props> = ({
   isOpen,
   onClose,
 }) => {
+  const { t } = useLocale();
   const [magicLinkSelected, setMagicLinkSelected] = useState<boolean>(false);
   const [safeLinkSelected, setSafeLinkSelected] = useState<boolean>(false);
   const [walletConnectSelected, setWalletConnectSelected] =
@@ -27,9 +31,9 @@ export const ConnectWalletModal: FC<Props> = ({
       <ModalBase maxWidth="600px" onClose={onClose} isOpen={isOpen}>
         <Box mt={8} mb={4}>
           <Text mb={4} textAlign="center" fontWeight="bold" fontSize="xl">
-            Welcome to MintRally!
-            <br/>
-            MintRally へようこそ
+            <WelcomeModal
+              welcomeText={t.WELCOME}
+            ></WelcomeModal>
           </Text>
           <Grid gap={2} justifyContent="center">
             {!magicLinkSelected &&
@@ -59,10 +63,9 @@ export const ConnectWalletModal: FC<Props> = ({
         </Box>
           <Box p={4} mb={0}>
             <Text mb={4} textAlign="center" fontWeight="normal" fontSize="sm">
-              Please connect your wallet to this website only if you agree to the Terms of Use and Privacy Policy.
-              <br/>
-              <br/>
-              利用規約、プライバシーポリシーにご同意いただいた場合のみ本ウェブサイトにウォレットを接続してください。
+              <AgreementModal
+               agreementText={t.AGREEMENT}
+              ></AgreementModal>
             </Text>
           </Box>
       </ModalBase>

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -14,6 +14,7 @@ export default {
   PLEASE_SWITCH_NETWORK: "Please switch network to the correct network.",
   PLEASE_SIGN_IN: "Please sign in first!",
   AGREEMENT: "Please connect your wallet to this website only if you agree to the Terms of Use and Privacy Policy.",
+  WELCOME: "Welcome to MintRally!",
   //Connect Wallet
   CONNECT_WITH_METAMASK: "Connect with Metamask",
   CONNECT_WITH_EMAIL: "Connect with Email",

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -13,6 +13,7 @@ export default {
   SWITCH_NETWORK: "Switch Network",
   PLEASE_SWITCH_NETWORK: "Please switch network to the correct network.",
   PLEASE_SIGN_IN: "Please sign in first!",
+  AGREEMENT: "Please connect your wallet to this website only if you agree to the Terms of Use and Privacy Policy.",
   //Connect Wallet
   CONNECT_WITH_METAMASK: "Connect with Metamask",
   CONNECT_WITH_EMAIL: "Connect with Email",

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -13,6 +13,7 @@ export default {
   SWITCH_NETWORK: "ネットワーク切替",
   PLEASE_SWITCH_NETWORK: "正しいネットワークに切り替えてください。",
   PLEASE_SIGN_IN: "ログインしてください。",
+  AGREEMENT: "利用規約、プライバシーポリシーにご同意いただいた場合のみ本ウェブサイトにウォレットを接続してください。",
   // NFT
   NFT_NAME: "NFT名",
   NFT_DESC: "NFT説明",

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -14,6 +14,7 @@ export default {
   PLEASE_SWITCH_NETWORK: "正しいネットワークに切り替えてください。",
   PLEASE_SIGN_IN: "ログインしてください。",
   AGREEMENT: "利用規約、プライバシーポリシーにご同意いただいた場合のみ本ウェブサイトにウォレットを接続してください。",
+  WELCOME: "MintRally へようこそ！",
   // NFT
   NFT_NAME: "NFT名",
   NFT_DESC: "NFT説明",

--- a/frontend/src/pages/event-groups/new.tsx
+++ b/frontend/src/pages/event-groups/new.tsx
@@ -14,13 +14,14 @@ const NewEventGroupPage: NextPage = () => {
   const address = useAddress();
 
   return (
-    <Container maxW={800}>
+    <Container maxW={1000}>
       <Heading as="h1" fontSize="3xl" my={6}>
         {t.CREATE_NEW_EVENT_GROUP}
       </Heading>
       <LoginRequired
         requiredChainID={+process.env.NEXT_PUBLIC_CHAIN_ID!}
         forbiddenText={t.PLEASE_SIGN_IN}
+        agreementText={t.AGREEMENT}
       >
         {address && <CreateEventGroupForm address={address} />}
       </LoginRequired>

--- a/frontend/src/pages/events/new.tsx
+++ b/frontend/src/pages/events/new.tsx
@@ -11,7 +11,7 @@ const EventCreate: NextPage = () => {
 
   return (
     <>
-      <Container maxW={800} py={6}>
+      <Container maxW={1000} py={6}>
         <Heading as="h1" fontSize="3xl" color="text.black" mb={10}>
           {t.CREATE_NEW_EVENT}
         </Heading>
@@ -19,6 +19,7 @@ const EventCreate: NextPage = () => {
         <LoginRequired
           requiredChainID={+process.env.NEXT_PUBLIC_CHAIN_ID!}
           forbiddenText={t.PLEASE_SIGN_IN}
+          agreementText={t.AGREEMENT}
         >
           {address && <CreateEventForm address={address} />}
         </LoginRequired>

--- a/frontend/src/pages/users/me.tsx
+++ b/frontend/src/pages/users/me.tsx
@@ -11,7 +11,10 @@ const User: FC = () => {
 
   return (
     <Container maxWidth={1000} mt={{ base: 5, md: 10 }}>
-      <LoginRequired forbiddenText={t.PLEASE_SIGN_IN}>
+      <LoginRequired 
+       forbiddenText={t.PLEASE_SIGN_IN}
+       agreementText={t.AGREEMENT}
+      >
         {address && <UserEntity address={address} />}
       </LoginRequired>
     </Container>


### PR DESCRIPTION
# 改善

- 全ての該当箇所に「利用規約、プライバシーポリシーにご同意いただいた場合のみ本ウェブサイトにウォレットを接続してください。」を追加
- 英語を追加し，モーダルを言語化
- フッターに「Terms」「Privacy」「SCTA」ボタンを追加し，レイアウトを少し変更

<img width="1020" alt="image" src="https://github.com/hackdays-io/mint-rally/assets/67133469/355ea1db-16bd-4602-97ce-9e51915ad340">

**モーダル（英語版）**
<img width="615" alt="image" src="https://github.com/hackdays-io/mint-rally/assets/67133469/1950256d-d01a-4502-9c8f-70c0ce96288a">

**フッター**
<img width="305" alt="image" src="https://github.com/hackdays-io/mint-rally/assets/67133469/8157aca6-360d-4e27-b34b-4bd862918d29">
