### PR TITLE
Feature/burn by user

### DIFF
--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -163,11 +163,23 @@ contract MintNFT is
             metaDataURL = specialMetaDataURL;
         }
 
-        nftMetaDataURL[_tokenIds.current()] = metaDataURL;
-        tokenIdsByEvent[_eventId].push(_tokenIds.current());
-        _safeMint(_msgSender(), _tokenIds.current());
+//        nftMetaDataURL[_tokenIds.current()] = metaDataURL;
+//        tokenIdsByEvent[_eventId].push(_tokenIds.current());
+//        _safeMint(_msgSender(), _tokenIds.current());
 
         _tokenIds.increment();
+        
+        // 追記
+       uint256 newTokenId = _tokenIds.current();
+
+        // トークンIDの重複チェック
+        require(!_exists(newTokenId), "Token already minted");
+
+        nftMetaDataURL[newTokenId] = metaDataURL;
+        tokenIdsByEvent[_eventId].push(newTokenId);
+        _safeMint(_msgSender(), newTokenId);
+        // 追記ここまで
+
         emit MintedNFTAttributeURL(_msgSender(), metaDataURL);
     }
 
@@ -286,15 +298,22 @@ contract MintNFT is
         return _nftAttributeRecords;
     }
 
+    // 新しいイベント定義
+ //   event BurnByOwner(uint256 indexed tokenId);
+ //   event Burn(uint256 indexed tokenId);
+    event TokenBurned(uint256 tokenId);
+
     // 既存の burn 関数の名前を変更
     function burnByOwner(uint256 tokenId) public onlyOwner {
-    _burn(tokenId);
+        require(_exists(tokenId), "Token does not exist");
+        _burn(tokenId);
     }
     
     // ユーザーが自身のNFTをバーンできるようにする新しい burn 関数
     function burn(uint256 tokenId) public {
-    require(_isApprovedOrOwner(_msgSender(), tokenId), "caller is not owner nor approved");
+    require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721Burnable: caller is not owner nor approved");
     _burn(tokenId);
+    emit TokenBurned(tokenId);
     }
 
     function tokenURI(

--- a/hardhat/contracts/MintNFT.sol
+++ b/hardhat/contracts/MintNFT.sol
@@ -286,8 +286,15 @@ contract MintNFT is
         return _nftAttributeRecords;
     }
 
-    function burn(uint256 tokenId) public onlyOwner {
-        _burn(tokenId);
+    // 既存の burn 関数の名前を変更
+    function burnByOwner(uint256 tokenId) public onlyOwner {
+    _burn(tokenId);
+    }
+    
+    // ユーザーが自身のNFTをバーンできるようにする新しい burn 関数
+    function burn(uint256 tokenId) public {
+    require(_isApprovedOrOwner(_msgSender(), tokenId), "caller is not owner nor approved");
+    _burn(tokenId);
     }
 
     function tokenURI(

--- a/hardhat/test/MintNFT.ts
+++ b/hardhat/test/MintNFT.ts
@@ -251,6 +251,10 @@ describe("MintNFT", function () {
         0
       );
 
+      // participant2がorganizerにトークンの操作を承認
+      await mintNFT.connect(participant2).approve(organizer.address, tokenId);
+
+      // 承認後にburnを実行
       await mintNFT.connect(organizer).burn(tokenId);
       expect(await mintNFT.balanceOf(participant2.address)).equal(0);
     });


### PR DESCRIPTION
対応遅れてすみません。
以下テストコード修正しましたが、おそらくゼロ知識証明のモック関数の部分でエラーが直りませんでした。お手隙の際にレビューお願いします。

・burnとburnByOwnerのそれぞれにテストコードを追加
→burn() と burnByOwner() のテストを用意
・また、どちらにもバーンが失敗するケースのテストも追加
・burnByOwner() のテストに所有者によるバーンのテストを追加

＜その他＞
・作業ブランチ名の変更（済）
→feature/burn-by-userに変更