### PR TITLE
Allow external access to retrieve whether or not a person is a participant in the event.

### DIFF
--- a/hardhat/contracts/IMintNFT.sol
+++ b/hardhat/contracts/IMintNFT.sol
@@ -45,6 +45,11 @@ interface IMintNFT {
         string memory _secretPhrase
     ) external;
 
+    function isHoldingEventNFTByAddress(
+        address _address,
+        uint256 _eventId
+    ) external view returns (bool);
+
     function name() external view returns (string memory);
 
     function owner() external view returns (address);


### PR DESCRIPTION
# Isuues
https://github.com/hackdays-io/mint-rally/issues/432

# 改修内容
IMintNFT.solにisHoldingEventNFTByAddressを追加

## 補足

チケットの目的としては、「指定されたアドレスがイベントIDを持っているかどうかをチェックし、同じイベントに重複参加しないように制限する」と把握しています。

目的の関数は下記行で既に実装されていたため変更なしです。
https://github.com/hackdays-io/mint-rally/blob/staging/hardhat/contracts/MintNFT.sol#L270-L276

テスト（同じアドレスが同じイベントに2回参加した場合、その人に対してNFT（非代替トークン）を発行しない）も下記行で既に実装されていため変更なしです。
https://github.com/hackdays-io/mint-rally/blob/staging/hardhat/test/MintNFT.ts#L633-L646

# 動作確認
`yarn run test test/MintNFT.ts`が全て通ることを確認しました。
